### PR TITLE
[RFC] Add Schema and column getters to Change

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Change.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Change.java
@@ -1,12 +1,18 @@
 package com.scylladb.cdc.cql.driver3;
 
-import static com.datastax.driver.core.Metadata.quoteIfNecessary;
-
+import com.datastax.driver.core.ColumnDefinitions;
+import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.Row;
 import com.google.common.base.Preconditions;
 import com.scylladb.cdc.model.StreamId;
 import com.scylladb.cdc.model.worker.Change;
 import com.scylladb.cdc.model.worker.ChangeId;
+import com.scylladb.cdc.model.worker.ChangeSchema;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static com.datastax.driver.core.Metadata.quoteIfNecessary;
 
 public final class Driver3Change implements Change {
     private final Row row;
@@ -19,6 +25,46 @@ public final class Driver3Change implements Change {
     public ChangeId getId() {
         return new ChangeId(new StreamId(row.getBytes(quoteIfNecessary("cdc$stream_id"))),
                 row.getUUID(quoteIfNecessary("cdc$time")));
+    }
+
+    @Override
+    public ChangeSchema getSchema() {
+        List<ColumnDefinitions.Definition> driverColumnDefinitions = row.getColumnDefinitions().asList();
+        List<ChangeSchema.ColumnDefinition> columnDefinitions =
+                driverColumnDefinitions.stream().map(this::translateColumnDefinition).collect(Collectors.toList());
+        return new ChangeSchema(columnDefinitions);
+    }
+
+    @Override
+    public int getInt(String columnName) {
+        return row.getInt(columnName);
+    }
+
+    private ChangeSchema.ColumnDefinition translateColumnDefinition(ColumnDefinitions.Definition driverDefinition) {
+        String columnName = driverDefinition.getName();
+        ChangeSchema.ColumnType columnType = translateColumnType(driverDefinition.getType());
+        return new ChangeSchema.ColumnDefinition(columnName, columnType);
+    }
+
+    private ChangeSchema.ColumnType translateColumnType(DataType driverType) {
+        switch (driverType.getName()) {
+            case INT:
+                return ChangeSchema.ColumnType.INT;
+            case TEXT:
+                return ChangeSchema.ColumnType.TEXT;
+            case BLOB:
+                return ChangeSchema.ColumnType.BLOB;
+            case TIMEUUID:
+                return ChangeSchema.ColumnType.TIMEUUID;
+            case BOOLEAN:
+                return ChangeSchema.ColumnType.BOOLEAN;
+            case TINYINT:
+                return ChangeSchema.ColumnType.TINYINT;
+            case BIGINT:
+                return ChangeSchema.ColumnType.BIGINT;
+            default:
+                throw new RuntimeException(String.format("Type %s is currently not supported.", driverType.getName()));
+        }
     }
 
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/Change.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/Change.java
@@ -4,4 +4,8 @@ public interface Change {
 
     ChangeId getId();
 
+    ChangeSchema getSchema();
+
+    int getInt(String columnName);
+
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/ChangeSchema.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/ChangeSchema.java
@@ -1,0 +1,37 @@
+package com.scylladb.cdc.model.worker;
+
+import java.util.List;
+
+public final class ChangeSchema {
+    public enum ColumnType {
+        INT, TINYINT, BIGINT, TEXT, BLOB, TIMEUUID, BOOLEAN
+    }
+
+    public static final class ColumnDefinition {
+        private final String columnName;
+        private final ColumnType columnType;
+
+        public ColumnDefinition(String columnName, ColumnType columnType) {
+            this.columnName = columnName;
+            this.columnType = columnType;
+        }
+
+        public String getColumnName() {
+            return columnName;
+        }
+
+        public ColumnType getColumnType() {
+            return columnType;
+        }
+    }
+
+    private final List<ColumnDefinition> columnDefinitions;
+
+    public ChangeSchema(List<ColumnDefinition> columnDefinitions) {
+        this.columnDefinitions = columnDefinitions;
+    }
+
+    public List<ColumnDefinition> getColumnDefinitions() {
+        return columnDefinitions;
+    }
+}


### PR DESCRIPTION
Add new `getSchema()` and `getInt(columnName)` methods to `Change`, which
allow for querying the schema of a given `Change` and accessing the data
in the row of the change.

New `ChangeSchema` class is introduced to provide a common interface
between many driver versions (and possibly mock for tests).

Update `Driver3Change` to implement new methods.

Things still left to do:
- Cleanup the commit (`import`s)
- Add more getters: only `getInt` implemented now
- Modify `Driver3` to not build the `ChangeSchema` for each row. Instead build it once per window/query.
- Maybe add CDC-specific getters (to get operation type, etc.)
- Add `versionId` to `ChangeSchema` to make it easy to detect if the schema changed