### PR TITLE
Further work on ChangeSchema

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Change.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Change.java
@@ -2,14 +2,8 @@ package com.scylladb.cdc.cql.driver3;
 
 import static com.datastax.driver.core.Metadata.quoteIfNecessary;
 
-import java.util.List;
-
-import com.datastax.driver.core.ColumnDefinitions;
-import com.datastax.driver.core.DataType;
 import com.datastax.driver.core.Row;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 import com.scylladb.cdc.model.StreamId;
 import com.scylladb.cdc.model.worker.Change;
 import com.scylladb.cdc.model.worker.ChangeId;
@@ -17,9 +11,11 @@ import com.scylladb.cdc.model.worker.ChangeSchema;
 
 public final class Driver3Change implements Change {
     private final Row row;
+    private final ChangeSchema schema;
 
-    public Driver3Change(Row row) {
+    public Driver3Change(Row row, ChangeSchema schema) {
         this.row = Preconditions.checkNotNull(row);
+        this.schema = Preconditions.checkNotNull(schema);
     }
 
     @Override
@@ -30,42 +26,24 @@ public final class Driver3Change implements Change {
 
     @Override
     public ChangeSchema getSchema() {
-        List<ColumnDefinitions.Definition> driverColumnDefinitions = row.getColumnDefinitions().asList();
-        Builder<ChangeSchema.ColumnDefinition> builder = ImmutableList.builder();
-        driverColumnDefinitions.stream().map(this::translateColumnDefinition).forEach(builder::add);
-        return new ChangeSchema(builder.build());
+        return schema;
     }
 
     @Override
-    public int getInt(String columnName) {
-        return row.getInt(columnName);
-    }
-
-    private ChangeSchema.ColumnDefinition translateColumnDefinition(ColumnDefinitions.Definition driverDefinition) {
-        String columnName = driverDefinition.getName();
-        ChangeSchema.ColumnType columnType = translateColumnType(driverDefinition.getType());
-        return new ChangeSchema.ColumnDefinition(columnName, columnType);
-    }
-
-    private ChangeSchema.ColumnType translateColumnType(DataType driverType) {
-        switch (driverType.getName()) {
-        case INT:
-            return ChangeSchema.ColumnType.INT;
-        case TEXT:
-            return ChangeSchema.ColumnType.TEXT;
-        case BLOB:
-            return ChangeSchema.ColumnType.BLOB;
-        case TIMEUUID:
-            return ChangeSchema.ColumnType.TIMEUUID;
-        case BOOLEAN:
-            return ChangeSchema.ColumnType.BOOLEAN;
-        case TINYINT:
-            return ChangeSchema.ColumnType.TINYINT;
-        case BIGINT:
-            return ChangeSchema.ColumnType.BIGINT;
-        default:
-            throw new RuntimeException(String.format("Type %s is currently not supported.", driverType.getName()));
+    public Integer getInt(String columnName) {
+        if (row.isNull(columnName)) {
+            return null;
+        } else {
+            return row.getInt(columnName);
         }
     }
 
+    @Override
+    public Byte getByte(String columnName) {
+        if (row.isNull(columnName)) {
+            return null;
+        } else {
+            return row.getByte(columnName);
+        }
+    }
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3SchemaBuilder.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3SchemaBuilder.java
@@ -1,0 +1,103 @@
+package com.scylladb.cdc.cql.driver3;
+
+import com.datastax.driver.core.ColumnDefinitions;
+import com.datastax.driver.core.ColumnMetadata;
+import com.datastax.driver.core.DataType;
+import com.datastax.driver.core.Metadata;
+import com.datastax.driver.core.Row;
+import com.datastax.driver.core.TableMetadata;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.scylladb.cdc.model.worker.Change;
+import com.scylladb.cdc.model.worker.ChangeSchema;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class Driver3SchemaBuilder {
+    private static final String SCYLLA_CDC_LOG_SUFFIX = "_scylla_cdc_log";
+
+    private Row row;
+    private String keyspace;
+    private String tableName;
+    private String baseTableName;
+    private Metadata metadata;
+
+    private Set<String> baseTablePartitionKeyColumnNames;
+    private Set<String> baseTableClusteringKeyColumnNames;
+
+    public Driver3SchemaBuilder withRow(Row row) {
+        this.row = Preconditions.checkNotNull(row);
+        this.keyspace = row.getColumnDefinitions().getKeyspace(0);
+        this.tableName = row.getColumnDefinitions().getTable(0);
+        Preconditions.checkArgument(this.tableName.endsWith(SCYLLA_CDC_LOG_SUFFIX));
+        this.baseTableName = tableName.substring(0, tableName.length() - SCYLLA_CDC_LOG_SUFFIX.length());
+        return this;
+    }
+
+    public Driver3SchemaBuilder withClusterMetadata(Metadata metadata) {
+        this.metadata = Preconditions.checkNotNull(metadata);
+        return this;
+    }
+
+    public ChangeSchema build() {
+        generatePrimaryKeyColumns();
+
+        return new ChangeSchema(generateChangeSchemaColumns());
+    }
+
+    private void generatePrimaryKeyColumns() {
+        Preconditions.checkNotNull(keyspace);
+        Preconditions.checkNotNull(baseTableName);
+        Preconditions.checkNotNull(metadata);
+
+        TableMetadata baseTableMetadata = metadata.getKeyspace(keyspace).getTable(baseTableName);
+        baseTablePartitionKeyColumnNames = baseTableMetadata.getPartitionKey().stream().map(ColumnMetadata::getName).collect(Collectors.toSet());
+        baseTableClusteringKeyColumnNames = baseTableMetadata.getClusteringColumns().stream().map(ColumnMetadata::getName).collect(Collectors.toSet());
+    }
+
+    private ImmutableList<ChangeSchema.ColumnDefinition> generateChangeSchemaColumns() {
+        Preconditions.checkNotNull(row);
+        Preconditions.checkNotNull(baseTablePartitionKeyColumnNames);
+        Preconditions.checkNotNull(baseTableClusteringKeyColumnNames);
+
+        List<ColumnDefinitions.Definition> driverColumnDefinitions = row.getColumnDefinitions().asList();
+        ImmutableList.Builder<ChangeSchema.ColumnDefinition> builder = ImmutableList.builder();
+        driverColumnDefinitions.stream().map(this::translateColumnDefinition).forEach(builder::add);
+        return builder.build();
+    }
+
+    private ChangeSchema.ColumnDefinition translateColumnDefinition(ColumnDefinitions.Definition driverDefinition) {
+        String columnName = driverDefinition.getName();
+        ChangeSchema.DataType dataType = translateColumnDataType(driverDefinition.getType());
+        ChangeSchema.ColumnType columnType = ChangeSchema.ColumnType.REGULAR;
+        if (baseTablePartitionKeyColumnNames.contains(columnName)) {
+            columnType = ChangeSchema.ColumnType.PARTITION_KEY;
+        } else if (baseTableClusteringKeyColumnNames.contains(columnName)) {
+            columnType = ChangeSchema.ColumnType.CLUSTERING_KEY;
+        }
+        return new ChangeSchema.ColumnDefinition(columnName, dataType, columnType);
+    }
+
+    private ChangeSchema.DataType translateColumnDataType(DataType driverType) {
+        switch (driverType.getName()) {
+            case INT:
+                return ChangeSchema.DataType.INT;
+            case TEXT:
+                return ChangeSchema.DataType.TEXT;
+            case BLOB:
+                return ChangeSchema.DataType.BLOB;
+            case TIMEUUID:
+                return ChangeSchema.DataType.TIMEUUID;
+            case BOOLEAN:
+                return ChangeSchema.DataType.BOOLEAN;
+            case TINYINT:
+                return ChangeSchema.DataType.TINYINT;
+            case BIGINT:
+                return ChangeSchema.DataType.BIGINT;
+            default:
+                throw new RuntimeException(String.format("Data type %s is currently not supported.", driverType.getName()));
+        }
+    }
+}

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/Change.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/Change.java
@@ -6,6 +6,8 @@ public interface Change {
 
     ChangeSchema getSchema();
 
-    int getInt(String columnName);
+    Integer getInt(String columnName);
+
+    Byte getByte(String columnName);
 
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/ChangeSchema.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/ChangeSchema.java
@@ -3,17 +3,25 @@ package com.scylladb.cdc.model.worker;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
+import java.util.Objects;
+
 public final class ChangeSchema {
-    public enum ColumnType {
+    public enum DataType {
         INT, TINYINT, BIGINT, TEXT, BLOB, TIMEUUID, BOOLEAN
+    }
+
+    public enum ColumnType {
+        REGULAR, PARTITION_KEY, CLUSTERING_KEY
     }
 
     public static final class ColumnDefinition {
         private final String columnName;
+        private final DataType dataType;
         private final ColumnType columnType;
 
-        public ColumnDefinition(String columnName, ColumnType columnType) {
+        public ColumnDefinition(String columnName, DataType dataType, ColumnType columnType) {
             this.columnName = columnName;
+            this.dataType = dataType;
             this.columnType = columnType;
         }
 
@@ -21,8 +29,27 @@ public final class ChangeSchema {
             return columnName;
         }
 
+        public DataType getDataType() {
+            return dataType;
+        }
+
         public ColumnType getColumnType() {
             return columnType;
+        }
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) return true;
+            if (o == null || getClass() != o.getClass()) return false;
+            ColumnDefinition that = (ColumnDefinition) o;
+            return columnName.equals(that.columnName) &&
+                    dataType == that.dataType &&
+                    columnType == that.columnType;
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(columnName, dataType, columnType);
         }
     }
 
@@ -34,5 +61,18 @@ public final class ChangeSchema {
 
     public ImmutableList<ColumnDefinition> getColumnDefinitions() {
         return columnDefinitions;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ChangeSchema that = (ChangeSchema) o;
+        return columnDefinitions.equals(that.columnDefinitions);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(columnDefinitions);
     }
 }


### PR DESCRIPTION
Sorry for grouping all those changes into single commit. (If it's important,
I can split them).

Renamed columnType to dataType and introduced new columnType, which
describes if a given column is part of primary key (partition or
clustering column) or a regular column.

Added equals() and hashCode() to ChangeSchema and ColumnDefinition.

Moved building Schema from Driver3Change to Driver3SchemaBuilder.
The ChangeSchema is now built only once at a start of a query.

Changed getInt() to return Integer (to support null in columns).
Introduced getByte() method.