### PR TITLE
Fix handling non-frozen list preimages

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3FromLibraryTranslator.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3FromLibraryTranslator.java
@@ -118,7 +118,7 @@ public class Driver3FromLibraryTranslator {
         return CodecRegistry.DEFAULT_INSTANCE.codecFor(driverDataType);
     }
 
-    private DataType getDriverDataType(ChangeSchema.DataType libraryDataType) {
+    public DataType getDriverDataType(ChangeSchema.DataType libraryDataType) {
         switch (libraryDataType.getCqlType()) {
             case ASCII:
                 return DataType.ascii();

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3ToLibraryTranslator.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3ToLibraryTranslator.java
@@ -1,14 +1,5 @@
 package com.scylladb.cdc.cql.driver3;
 
-import com.datastax.driver.core.Duration;
-import com.datastax.driver.core.LocalDate;
-import com.datastax.driver.core.TupleValue;
-import com.datastax.driver.core.UDTValue;
-import com.scylladb.cdc.model.worker.cql.CqlDate;
-import com.scylladb.cdc.model.worker.cql.CqlDuration;
-import com.scylladb.cdc.model.worker.cql.Field;
-import com.scylladb.cdc.model.worker.ChangeSchema;
-
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
@@ -17,12 +8,25 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+import com.datastax.driver.core.Duration;
+import com.datastax.driver.core.LocalDate;
+import com.datastax.driver.core.TupleValue;
+import com.datastax.driver.core.UDTValue;
+import com.scylladb.cdc.model.worker.ChangeSchema;
+import com.scylladb.cdc.model.worker.cql.CqlDate;
+import com.scylladb.cdc.model.worker.cql.CqlDuration;
+import com.scylladb.cdc.model.worker.cql.Field;
+
 public class Driver3ToLibraryTranslator {
     public static Object translate(Object driverObject, ChangeSchema.DataType dataType) {
         // Some types returned by getObject() are
         // some classes of Java Driver. We should
         // translate them into a non-Java-Driver-specific
         // types. (for example UDTValue)
+
+        // TODO: this takes ChangeSchema.DataType, but we sometimes want to translate objects
+        // that don't come from changes (i.e. not from CDC log tables), but from base table reads,
+        // e.g. in preimage mode. So perhaps it should take a more general DataType type...
 
         if (driverObject == null) {
             return null;

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3WorkerCQL.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3WorkerCQL.java
@@ -29,8 +29,8 @@ import com.google.common.util.concurrent.Futures;
 import com.scylladb.cdc.cql.WorkerCQL;
 import com.scylladb.cdc.model.StreamId;
 import com.scylladb.cdc.model.TableName;
-import com.scylladb.cdc.model.worker.RawChange;
 import com.scylladb.cdc.model.worker.ChangeSchema;
+import com.scylladb.cdc.model.worker.RawChange;
 import com.scylladb.cdc.model.worker.Task;
 
 public final class Driver3WorkerCQL implements WorkerCQL {
@@ -124,6 +124,11 @@ public final class Driver3WorkerCQL implements WorkerCQL {
                     schema = new Driver3SchemaBuilder()
                             .withClusterMetadata(session.getCluster().getMetadata())
                             .withRow(row).build();
+                } else {
+                    // TODO: the schema might have changed
+                    // is there some hash/digest that we can use to check that?
+                    // it wouldn't be nice if we had to update `schema` on each query/page (expensive)
+                    // See Scylla issue #7824.
                 }
                 fut.complete(Optional.of(new Driver3RawChange(row, schema)));
             }


### PR DESCRIPTION
For base list type `list<V>`, the type of the CDC value column is `map<timeuuid, V>`.
When replicating in preimage mode, we want to compare preimages with
results of querying the destination cluster; for that, we need to
translate the preimages, which come as `map<timeuuid, V>` values, into
list values, by dropping all the keys.

Fixes #5.