### PR TITLE
Implement retrying in master and backoff in workers

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/ExponentialRetryBackoffWithJitter.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/ExponentialRetryBackoffWithJitter.java
@@ -1,0 +1,31 @@
+package com.scylladb.cdc.model;
+
+import com.google.common.base.Preconditions;
+
+import java.util.Random;
+
+public class ExponentialRetryBackoffWithJitter implements RetryBackoff {
+    private final Random random;
+    private final int maximumBackoffMs;
+    private final int backoffBase;
+
+    public ExponentialRetryBackoffWithJitter(int backoffBase, int maximumBackoffMs) {
+        Preconditions.checkArgument(maximumBackoffMs > 0);
+        this.maximumBackoffMs = maximumBackoffMs;
+
+        Preconditions.checkArgument(backoffBase > 0);
+        this.backoffBase = backoffBase;
+
+        this.random = new Random();
+    }
+
+    @Override
+    public int getRetryBackoffTimeMs(int tryAttempt) {
+        // Performing the calculation in doubles, because doing the exponentation
+        // in int could result in overflow. But in case of doubles, overflow will equal
+        // +Infinity. Math.min() then will properly limit it to maximumBackoffMs.
+        int backoff = (int) Math.min(maximumBackoffMs, (double) backoffBase * Math.pow(2.0, tryAttempt));
+        // Add jitter.
+        return random.nextInt(backoff);
+    }
+}

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/FutureUtils.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/FutureUtils.java
@@ -1,0 +1,34 @@
+package com.scylladb.cdc.model;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+
+public final class FutureUtils {
+    private static class ComposeExceptionallyWrapper<T> {
+        T result;
+        Throwable throwable;
+
+        public ComposeExceptionallyWrapper(T result, Throwable throwable) {
+            this.result = result;
+            this.throwable = throwable;
+        }
+    }
+
+    /*
+     * If |fut| completes exceptionally, apply |exceptionally| function to
+     * its exception. Similar to CompletableFuture's thenCompose, but
+     * composing when the future completed exceptionally.
+     */
+    public static <T> CompletableFuture<T> thenComposeExceptionally(CompletableFuture<T> fut, Function<Throwable, ? extends CompletionStage<T>> exceptionally) {
+        return fut.handle((res, ex) -> {
+            return new ComposeExceptionallyWrapper(res, ex);
+        }).thenCompose((wrapper) -> {
+            if (wrapper.throwable == null) {
+                return CompletableFuture.completedFuture((T) wrapper.result);
+            } else {
+                return exceptionally.apply(wrapper.throwable);
+            }
+        });
+    }
+}

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/RetryBackoff.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/RetryBackoff.java
@@ -1,0 +1,5 @@
+package com.scylladb.cdc.model;
+
+public interface RetryBackoff {
+    int getRetryBackoffTimeMs(int tryAttempt);
+}

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/Connectors.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/Connectors.java
@@ -2,6 +2,7 @@ package com.scylladb.cdc.model.worker;
 
 import com.google.common.base.Preconditions;
 import com.scylladb.cdc.cql.WorkerCQL;
+import com.scylladb.cdc.model.RetryBackoff;
 import com.scylladb.cdc.transport.WorkerTransport;
 
 public final class Connectors {
@@ -12,8 +13,10 @@ public final class Connectors {
     public final long queryTimeWindowSizeMs;
     public final long confidenceWindowSizeMs;
 
+    public RetryBackoff workerRetryBackoff;
+
     public Connectors(WorkerTransport transport, WorkerCQL cql, TaskAndRawChangeConsumer consumer,
-                      long queryTimeWindowSizeMs, long confidenceWindowSizeMs) {
+                      long queryTimeWindowSizeMs, long confidenceWindowSizeMs, RetryBackoff workerRetryBackoff) {
         this.transport = Preconditions.checkNotNull(transport);
         this.cql = Preconditions.checkNotNull(cql);
         this.consumer = Preconditions.checkNotNull(consumer);
@@ -21,5 +24,6 @@ public final class Connectors {
         this.queryTimeWindowSizeMs = queryTimeWindowSizeMs;
         Preconditions.checkArgument(confidenceWindowSizeMs > 0);
         this.confidenceWindowSizeMs = confidenceWindowSizeMs;
+        this.workerRetryBackoff = Preconditions.checkNotNull(workerRetryBackoff);
     }
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/TaskAction.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/TaskAction.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.base.Preconditions;
 import com.google.common.flogger.FluentLogger;
 import com.scylladb.cdc.cql.WorkerCQL.Reader;
+import com.scylladb.cdc.model.FutureUtils;
 
 public abstract class TaskAction {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
@@ -26,32 +27,43 @@ public abstract class TaskAction {
                 }
             });
 
+    private static CompletableFuture<Void> sleepOnExecutor(long numberOfMilliseconds) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        internalExecutor.schedule(() -> result.complete(null), numberOfMilliseconds, TimeUnit.MILLISECONDS);
+        return result;
+    }
+
     public abstract CompletableFuture<TaskAction> run();
 
     public static TaskAction createFirstAction(Connectors connectors, Task task) {
-        return new ReadNewWindowTaskAction(connectors, task);
+        return new ReadNewWindowTaskAction(connectors, task, 0);
     }
 
     private static final class ReadNewWindowTaskAction extends TaskAction {
         private final Connectors connectors;
         private final Task task;
+        private final int tryAttempt;
 
-        protected ReadNewWindowTaskAction(Connectors connectors, Task task) {
+        protected ReadNewWindowTaskAction(Connectors connectors, Task task, int tryAttempt) {
             this.connectors = Preconditions.checkNotNull(connectors);
             this.task = Preconditions.checkNotNull(task);
+            Preconditions.checkArgument(tryAttempt >= 0);
+            this.tryAttempt = tryAttempt;
         }
 
         @Override
         public CompletableFuture<TaskAction> run() {
             CompletableFuture<Void> waitFuture = waitForWindow();
             CompletableFuture<Reader> readerFuture = waitFuture.thenCompose(w -> connectors.cql.createReader(task));
-            return readerFuture.thenApply(reader -> (TaskAction) new UpdateStatusTaskAction(connectors, task, reader)).exceptionally(ex -> {
+            CompletableFuture<TaskAction> taskActionFuture = readerFuture
+                    .thenApply(reader -> new UpdateStatusTaskAction(connectors, task, reader, tryAttempt));
+            return FutureUtils.thenComposeExceptionally(taskActionFuture, ex -> {
                 // Exception occured while starting up the reader. Retry by starting
                 // this TaskAction once again.
-                
-                // TODO - implement some backoff strategy.
-                logger.atSevere().withCause(ex).log("Error while starting reading next window. Task: %s. Task state: %s. Will retry.", task.id, task.state);
-                return new ReadNewWindowTaskAction(connectors, task);
+                long backoffTime = connectors.workerRetryBackoff.getRetryBackoffTimeMs(tryAttempt);
+                logger.atSevere().withCause(ex).log("Error while starting reading next window. Task: %s. " +
+                        "Task state: %s. Will retry after backoff (%d ms).", task.id, task.state, backoffTime);
+                return TaskAction.sleepOnExecutor(backoffTime).thenApply(t -> new ReadNewWindowTaskAction(connectors, task, tryAttempt + 1));
             });
         }
 
@@ -60,9 +72,7 @@ public abstract class TaskAction {
             Date now = new Date();
             long toWait = end.getTime() - now.getTime() + connectors.confidenceWindowSizeMs;
             if (toWait > 0) {
-                CompletableFuture<Void> result = new CompletableFuture<>();
-                internalExecutor.schedule(() -> result.complete(null), toWait, TimeUnit.MILLISECONDS);
-                return result;
+                return sleepOnExecutor(toWait);
             }
             return CompletableFuture.completedFuture(null);
         }
@@ -72,18 +82,21 @@ public abstract class TaskAction {
         protected final Connectors connectors;
         protected final Task task;
         private final Reader reader;
+        private final int tryAttempt;
 
-        public ConsumeChangeTaskAction(Connectors connectors, Task task, Reader reader) {
+        public ConsumeChangeTaskAction(Connectors connectors, Task task, Reader reader, int tryAttempt) {
             this.connectors = Preconditions.checkNotNull(connectors);
             this.task = Preconditions.checkNotNull(task);
             this.reader = Preconditions.checkNotNull(reader);
+            Preconditions.checkArgument(tryAttempt >= 0);
+            this.tryAttempt = tryAttempt;
         }
 
         private CompletableFuture<TaskAction> consumeChange(Optional<RawChange> change) {
             if (change.isPresent()) {
                 Task updatedTask = task.updateState(change.get().getId());
                 return connectors.consumer.consume(task, change.get())
-                        .thenApply(q -> new UpdateStatusTaskAction(connectors, updatedTask, reader));
+                        .thenApply(q -> new UpdateStatusTaskAction(connectors, updatedTask, reader, tryAttempt));
             } else {
                 CompletableFuture<TaskAction> result = new CompletableFuture<>();
                 result.complete(new MoveToNextWindowTaskAction(connectors, task));
@@ -93,22 +106,22 @@ public abstract class TaskAction {
 
         @Override
         public CompletableFuture<TaskAction> run() {
-            return reader.nextChange().thenCompose(this::consumeChange).exceptionally(ex -> {
+            CompletableFuture<TaskAction> taskActionFuture = reader.nextChange().thenCompose(this::consumeChange);
+            return FutureUtils.thenComposeExceptionally(taskActionFuture, ex -> {
                 // Exception occured while reading the window, we will have to restart
                 // ReadNewWindowTaskAction - read a window from state defined in task.
-
-                // TODO - implement some backoff strategy.
-                logger.atSevere().withCause(ex).log("Error while consuming change. Task: %s. Task state: %s. Will retry.", task.id, task.state);
-                return new ReadNewWindowTaskAction(connectors, task);
+                long backoffTime = connectors.workerRetryBackoff.getRetryBackoffTimeMs(tryAttempt);
+                logger.atSevere().withCause(ex).log("Error while consuming change. Task: %s. " +
+                        "Task state: %s. Will retry after backoff (%d ms).", task.id, task.state, backoffTime);
+                return TaskAction.sleepOnExecutor(backoffTime).thenApply(t -> new ReadNewWindowTaskAction(connectors, task, tryAttempt + 1));
             });
         }
-
     }
 
     private static final class UpdateStatusTaskAction extends ConsumeChangeTaskAction {
 
-        public UpdateStatusTaskAction(Connectors connectors, Task task, Reader reader) {
-            super(connectors, task, reader);
+        public UpdateStatusTaskAction(Connectors connectors, Task task, Reader reader, int tryAttempt) {
+            super(connectors, task, reader, tryAttempt);
         }
 
         @Override
@@ -133,7 +146,7 @@ public abstract class TaskAction {
             TaskState newState = task.state.moveToNextWindow(connectors.queryTimeWindowSizeMs);
             connectors.transport.moveStateToNextWindow(task.id, newState);
             Task newTask = task.updateState(newState);
-            return CompletableFuture.completedFuture(new ReadNewWindowTaskAction(connectors, newTask));
+            return CompletableFuture.completedFuture(new ReadNewWindowTaskAction(connectors, newTask, 0));
         }
     }
 }

--- a/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnector.java
+++ b/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnector.java
@@ -65,11 +65,8 @@ public class ScyllaConnector extends SourceConnector {
         this.masterExecutor = Threads.newSingleThreadExecutor(ScyllaConnector.class, connectorConfig.getLogicalName(),
                 "scylla-cdc-java-master-executor");
         this.masterExecutor.execute(() -> {
-            try {
-                master.run();
-            } catch (ExecutionException ex) {
-                logger.error("Error in the scylla-cdc-java library master.", ex);
-            }
+            master.run();
+            logger.info("scylla-cdc-java library master gracefully finished.");
         });
     }
 

--- a/scylla-cdc-lib/src/main/java/com/scylladb/cdc/lib/CDCConsumerBuilder.java
+++ b/scylla-cdc-lib/src/main/java/com/scylladb/cdc/lib/CDCConsumerBuilder.java
@@ -4,14 +4,24 @@ import java.util.Set;
 
 import com.datastax.driver.core.Session;
 import com.google.common.base.Preconditions;
+import com.scylladb.cdc.model.ExponentialRetryBackoffWithJitter;
+import com.scylladb.cdc.model.RetryBackoff;
 import com.scylladb.cdc.model.TableName;
 import com.scylladb.cdc.model.worker.RawChangeConsumer;
 
 public final class CDCConsumerBuilder {
+    private static final long DEFAULT_QUERY_TIME_WINDOW_SIZE_MS = 30000;
+    private static final long DEFAULT_CONFIDENCE_WINDOW_SIZE_MS = 30000;
+    private static final RetryBackoff DEFAULT_WORKER_RETRY_BACKOFF =
+            new ExponentialRetryBackoffWithJitter(10, 30000);
+
     private final Session session;
     private final RawChangeConsumerProvider consumer;
     private final Set<TableName> tables;
     private int workersCount = getDefaultWorkersCount();
+    private long queryTimeWindowSizeMs = DEFAULT_QUERY_TIME_WINDOW_SIZE_MS;
+    private long confidenceWindowSizeMs = DEFAULT_CONFIDENCE_WINDOW_SIZE_MS;
+    private RetryBackoff workerRetryBackoff = DEFAULT_WORKER_RETRY_BACKOFF;
 
     private CDCConsumerBuilder(Session session, RawChangeConsumerProvider consumer, Set<TableName> tables) {
         this.consumer = Preconditions.checkNotNull(consumer);
@@ -31,8 +41,26 @@ public final class CDCConsumerBuilder {
         return this;
     }
 
+    public CDCConsumerBuilder queryTimeWindowSizeMs(long windowSizeMs) {
+        Preconditions.checkArgument(windowSizeMs >= 0);
+        queryTimeWindowSizeMs = windowSizeMs;
+        return this;
+    }
+
+    public CDCConsumerBuilder confidenceWindowSizeMs(long windowSizeMs) {
+        Preconditions.checkArgument(windowSizeMs >= 0);
+        confidenceWindowSizeMs = windowSizeMs;
+        return this;
+    }
+
+    public CDCConsumerBuilder workerRetryBackoff(RetryBackoff retryBackoff) {
+        workerRetryBackoff = Preconditions.checkNotNull(retryBackoff);
+        return this;
+    }
+
     public CDCConsumer build() {
-        return new CDCConsumer(session, consumer, tables, workersCount);
+        return new CDCConsumer(session, consumer, tables, workersCount,
+                queryTimeWindowSizeMs, confidenceWindowSizeMs, workerRetryBackoff);
     }
 
     private static int getDefaultWorkersCount() {


### PR DESCRIPTION
This PR contains 3 commits:

1. Change the way background Master thread is created. (The new implementation is more inline with Debezium implementation). Additionally, the Session and Cluster objects are properly closed.
2. Implement retrying in Master. Previously in case of any exception in Master there would be no retrying. After this change, if there is an exception (for example CQL query error), the Master is effectively restarted. To avoid unnecessary code complexity, a fixed back-off time is used (10 seconds).
3. Implement back-off in workers. In case of an exception in Worker (for example CQL query error), the Worker immediately queued a retry TaskAction. That could cause a big load on Scylla cluster (retrying as fast as possible). To mitigate this problem, I added a backoff before a retry. By default, an exponential backoff with jitter is used (10ms backoff doubling up to 30s).