### PR TITLE
Add skipping of old generations

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/MasterCQL.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/MasterCQL.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 
 import com.scylladb.cdc.model.GenerationId;
+import com.scylladb.cdc.model.TableName;
 import com.scylladb.cdc.model.Timestamp;
 import com.scylladb.cdc.model.master.GenerationMetadata;
 
@@ -11,4 +12,5 @@ public interface MasterCQL {
     CompletableFuture<Optional<GenerationId>> fetchFirstGenerationId();
     CompletableFuture<GenerationMetadata> fetchGenerationMetadata(GenerationId id);
     CompletableFuture<Optional<Timestamp>> fetchGenerationEnd(GenerationId id);
+    CompletableFuture<Optional<Long>> fetchTableTTL(TableName tableName);
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3MasterCQL.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3MasterCQL.java
@@ -10,6 +10,7 @@ import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -17,6 +18,8 @@ import java.util.stream.Collectors;
 
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.ConsistencyLevel;
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.Metadata;
 import com.datastax.driver.core.PreparedStatement;
 import com.datastax.driver.core.RegularStatement;
 import com.datastax.driver.core.ResultSet;
@@ -24,6 +27,7 @@ import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
 import com.datastax.driver.core.Statement;
+import com.datastax.driver.core.TableMetadata;
 import com.google.common.base.Preconditions;
 import com.google.common.flogger.FluentLogger;
 import com.google.common.util.concurrent.FutureCallback;
@@ -31,10 +35,10 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.scylladb.cdc.cql.BaseMasterCQL;
 import com.scylladb.cdc.model.FutureUtils;
+import com.scylladb.cdc.model.TableName;
 
 public final class Driver3MasterCQL extends BaseMasterCQL {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
-
     private final Session session;
 
     // (Streams description table V2)
@@ -307,4 +311,51 @@ public final class Driver3MasterCQL extends BaseMasterCQL {
         });
     }
 
+    @Override
+    public CompletableFuture<Optional<Long>> fetchTableTTL(TableName tableName) {
+        Metadata metadata = session.getCluster().getMetadata();
+        KeyspaceMetadata keyspaceMetadata = metadata.getKeyspace(tableName.keyspace);
+        if (keyspaceMetadata == null) {
+            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
+                    String.format("Could not fetch the metadata of keyspace %s.", tableName.keyspace)));
+        }
+
+        TableMetadata tableMetadata = keyspaceMetadata.getTable(tableName.name);
+        if (tableMetadata == null) {
+            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
+                    String.format("Could not fetch the metadata of table %s.%s.", tableName.keyspace, tableName.name)));
+        }
+
+        if (!tableMetadata.getOptions().isScyllaCDC()) {
+            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
+                    String.format("Table %s.%s does not have Scylla CDC enabled.", tableName.keyspace, tableName.name)));
+        }
+
+        Map<String, String> scyllaCDCOptions = tableMetadata.getOptions().getScyllaCDCOptions();
+        if (scyllaCDCOptions == null) {
+            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
+                    String.format("Table %s.%s does not have Scylla CDC metadata, " +
+                            "even though CDC is enabled.", tableName.keyspace, tableName.name)));
+        }
+
+        String ttl = scyllaCDCOptions.get("ttl");
+        if (ttl == null) {
+            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
+                    String.format("Table %s.%s does not have a TTL value in its metadata, " +
+                            "even though Scylla CDC is enabled and the metadata is present.", tableName.keyspace, tableName.name)));
+        }
+
+        try {
+            long parsedTTL = Long.parseLong(ttl);
+            if (parsedTTL == 0) {
+                // TTL is disabled.
+                return CompletableFuture.completedFuture(Optional.empty());
+            } else {
+                return CompletableFuture.completedFuture(Optional.of(parsedTTL));
+            }
+        } catch (NumberFormatException ex) {
+            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
+                    String.format("Table %s.%s has invalid TTL value: %s.", tableName.keyspace, tableName.name, ttl)));
+        }
+    }
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/FutureUtils.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/FutureUtils.java
@@ -52,4 +52,10 @@ public final class FutureUtils {
         });
         return result;
     }
+
+    public static <T> CompletableFuture<T> exceptionalFuture(Throwable t) {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        future.completeExceptionally(t);
+        return future;
+    }
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/master/Connectors.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/master/Connectors.java
@@ -5,23 +5,26 @@ import com.scylladb.cdc.cql.MasterCQL;
 import com.scylladb.cdc.model.TableName;
 import com.scylladb.cdc.transport.MasterTransport;
 
+import java.time.Clock;
 import java.util.Set;
 
 public class Connectors {
     public final MasterTransport transport;
     public final MasterCQL cql;
     public final Set<TableName> tables;
+    public final Clock clock;
 
     public final long sleepBeforeFirstGenerationMs;
     public final long sleepBeforeGenerationDoneMs;
     public final long sleepAfterExceptionMs;
 
-    public Connectors(MasterTransport transport, MasterCQL cql, Set<TableName> tables,
+    public Connectors(MasterTransport transport, MasterCQL cql, Set<TableName> tables, Clock clock,
                       long sleepBeforeFirstGenerationMs, long sleepBeforeGenerationDoneMs, long sleepAfterExceptionMs) {
         this.transport = Preconditions.checkNotNull(transport);
         this.cql = Preconditions.checkNotNull(cql);
         this.tables = Preconditions.checkNotNull(tables);
         Preconditions.checkArgument(!tables.isEmpty());
+        this.clock = Preconditions.checkNotNull(clock);
 
         this.sleepBeforeFirstGenerationMs = sleepBeforeFirstGenerationMs;
         Preconditions.checkArgument(sleepBeforeFirstGenerationMs >= 0);

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/master/MasterTest.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/master/MasterTest.java
@@ -1,20 +1,31 @@
 package com.scylladb.cdc.model.master;
 
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import com.scylladb.cdc.cql.MockMasterCQL;
 import com.scylladb.cdc.model.TableName;
+import com.scylladb.cdc.model.Timestamp;
 import com.scylladb.cdc.transport.ConfigureWorkersTracker;
 import com.scylladb.cdc.transport.MockMasterTransport;
 import org.awaitility.core.ConditionFactory;
 import org.junit.jupiter.api.Test;
 
+import java.time.Clock;
+import java.time.ZoneOffset;
 import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
+import static com.scylladb.cdc.model.master.MockGenerationMetadata.mockGenerationMetadata;
 import static org.awaitility.Awaitility.with;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -24,17 +35,31 @@ public class MasterTest {
             with().pollInterval(1, TimeUnit.MILLISECONDS).await()
                     .atMost(DEFAULT_AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
+    // Test generations. To make life easier, test set with X+1 generations
+    // should start with the same generations as a test set with X generations
+    // (and a new one).
     private static final List<GenerationMetadata> TEST_SET_ONE_GENERATION = Lists.newArrayList(
-            MockGenerationMetadata.mockGenerationMetadata(5, Optional.empty(), 8)
+            mockGenerationMetadata(mockTimestamp(5), Optional.empty(), 8)
     );
 
     private static final List<GenerationMetadata> TEST_SET_TWO_GENERATIONS = Lists.newArrayList(
-            MockGenerationMetadata.mockGenerationMetadata(5, Optional.of(10L), 8),
-            MockGenerationMetadata.mockGenerationMetadata(10, Optional.empty(), 8)
+            mockGenerationMetadata(mockTimestamp(5), Optional.of(mockTimestamp(10)), 8),
+            mockGenerationMetadata(mockTimestamp(10), Optional.empty(), 8)
+    );
+
+    private static final List<GenerationMetadata> TEST_SET_THREE_GENERATIONS = Lists.newArrayList(
+            mockGenerationMetadata(mockTimestamp(5), Optional.of(mockTimestamp(10)), 8),
+            mockGenerationMetadata(mockTimestamp(10), Optional.of(mockTimestamp(30)), 8),
+            mockGenerationMetadata(mockTimestamp(30), Optional.empty(), 10)
     );
 
     private static final Set<TableName> TEST_SET_SINGLE_TABLE = Collections.singleton(
             new TableName("ks", "test")
+    );
+
+    private static final Set<TableName> TEST_SET_TWO_TABLES = Sets.newHashSet(
+            new TableName("ks", "test"),
+            new TableName("ks", "test2")
     );
 
     @Test
@@ -189,6 +214,149 @@ public class MasterTest {
             // ...and observe moving to the next generation.
             masterTransportTracker.awaitConfigureWorkers(TEST_SET_TWO_GENERATIONS.get(1), tableNames);
         }
+    }
+
+    @Test
+    public void testMasterSkipsGenerationsDueToSingleTableTTL() {
+        MockMasterTransport masterTransport = new MockMasterTransport();
+        ConfigureWorkersTracker masterTransportTracker = masterTransport.tracker(DEFAULT_AWAIT);
+
+        MockMasterCQL masterCQL = new MockMasterCQL(TEST_SET_THREE_GENERATIONS);
+        Set<TableName> tableNames = TEST_SET_SINGLE_TABLE;
+
+        // The generations are as follows (in minutes after epoch):
+        //  5 - 10
+        // 10 - 30
+        // 30 - infinity
+
+        Clock simulatedTime = Clock.fixed(mockTimestamp(32).toDate().toInstant(), ZoneOffset.systemDefault());
+
+        // First test.
+        //
+        // We start at minute 32 with TTL of 3 minutes (provided below in seconds).
+        // We should catch 2 generations.
+        masterCQL.setTablesTTL(Collections.singletonMap(tableNames.iterator().next(), Optional.of(3L * 60)));
+
+        try (MasterThread masterThread = new MasterThread(masterTransport, masterCQL, tableNames, simulatedTime)) {
+            // Verify that the transport received the second generation...
+            masterTransportTracker.awaitConfigureWorkers(TEST_SET_THREE_GENERATIONS.get(1), tableNames);
+
+            // ...make the second generation fully consumed...
+            masterTransport.setGenerationFullyConsumed(TEST_SET_THREE_GENERATIONS.get(1));
+
+            // ...and we should switch to the third generation...
+            masterTransportTracker.awaitConfigureWorkers(TEST_SET_THREE_GENERATIONS.get(2), tableNames);
+        }
+
+        // Second test.
+        //
+        // We start at minute 32 with TTL of 1 minute.
+        // We should catch only the last generation.
+        masterCQL.setTablesTTL(Collections.singletonMap(tableNames.iterator().next(), Optional.of(1L * 60)));
+
+        // Reset setGenerationFullyConsumed calls.
+        masterTransport.setCurrentFullyConsumedTimestamp(new Timestamp(new Date(0)));
+
+        try (MasterThread masterThread = new MasterThread(masterTransport, masterCQL, tableNames, simulatedTime)) {
+            // Verify that the transport received the third generation...
+            masterTransportTracker.awaitConfigureWorkers(TEST_SET_THREE_GENERATIONS.get(2), tableNames);
+        }
+
+        // Third test
+        //
+        // We start at minute 32 with TTL of 24 minutes.
+        // We should catch all generations.
+        masterCQL.setTablesTTL(Collections.singletonMap(tableNames.iterator().next(), Optional.of(24L * 60)));
+
+        // Reset setGenerationFullyConsumed calls.
+        masterTransport.setCurrentFullyConsumedTimestamp(new Timestamp(new Date(0)));
+
+        try (MasterThread masterThread = new MasterThread(masterTransport, masterCQL, tableNames, simulatedTime)) {
+            for (GenerationMetadata generation : TEST_SET_THREE_GENERATIONS) {
+                masterTransportTracker.awaitConfigureWorkers(generation, tableNames);
+                if (generation.isClosed()) {
+                    masterTransport.setGenerationFullyConsumed(generation);
+                }
+            }
+        }
+
+        // Fourth test
+        //
+        // We start at minute 32 with no TTL.
+        // We should catch all generations.
+        masterCQL.setTablesTTL(Collections.singletonMap(tableNames.iterator().next(), Optional.empty()));
+
+        // Reset setGenerationFullyConsumed calls.
+        masterTransport.setCurrentFullyConsumedTimestamp(new Timestamp(new Date(0)));
+
+        try (MasterThread masterThread = new MasterThread(masterTransport, masterCQL, tableNames, simulatedTime)) {
+            for (GenerationMetadata generation : TEST_SET_THREE_GENERATIONS) {
+                masterTransportTracker.awaitConfigureWorkers(generation, tableNames);
+                if (generation.isClosed()) {
+                    masterTransport.setGenerationFullyConsumed(generation);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testMasterSkipsGenerationsDueToMultipleTablesTTL() {
+        MockMasterTransport masterTransport = new MockMasterTransport();
+        ConfigureWorkersTracker masterTransportTracker = masterTransport.tracker(DEFAULT_AWAIT);
+
+        MockMasterCQL masterCQL = new MockMasterCQL(TEST_SET_THREE_GENERATIONS);
+        Set<TableName> tableNames = TEST_SET_TWO_TABLES;
+
+        // The generations are as follows (in minutes after epoch):
+        //  5 - 10
+        // 10 - 30
+        // 30 - infinity
+
+        Clock simulatedTime = Clock.fixed(mockTimestamp(32).toDate().toInstant(), ZoneOffset.systemDefault());
+
+        // First test.
+        //
+        // We start at minute 32 with TTL of 1 minute for first table and 6 minutes for second table.
+        // We should catch 2 generations.
+        masterCQL.setTablesTTL(new HashMap<TableName, Optional<Long>>() {{
+            Iterator<TableName> iterator = tableNames.iterator();
+            put(iterator.next(), Optional.of(1L * 60));
+            put(iterator.next(), Optional.of(6L * 60));
+        }});
+
+        try (MasterThread masterThread = new MasterThread(masterTransport, masterCQL, tableNames, simulatedTime)) {
+            masterTransportTracker.awaitConfigureWorkers(TEST_SET_THREE_GENERATIONS.get(1), tableNames);
+            masterTransport.setGenerationFullyConsumed(TEST_SET_THREE_GENERATIONS.get(1));
+
+            masterTransportTracker.awaitConfigureWorkers(TEST_SET_THREE_GENERATIONS.get(2), tableNames);
+        }
+
+        // Second test.
+        //
+        // We start at minute 32 with TTL of 1 minute for first table and disabled TTL for second table.
+        // We should catch all generations.
+        masterCQL.setTablesTTL(new HashMap<TableName, Optional<Long>>() {{
+            Iterator<TableName> iterator = tableNames.iterator();
+            put(iterator.next(), Optional.of(1L * 60));
+            put(iterator.next(), Optional.empty());
+        }});
+
+        // Reset setGenerationFullyConsumed calls.
+        masterTransport.setCurrentFullyConsumedTimestamp(new Timestamp(new Date(0)));
+
+        try (MasterThread masterThread = new MasterThread(masterTransport, masterCQL, tableNames, simulatedTime)) {
+            for (GenerationMetadata generation : TEST_SET_THREE_GENERATIONS) {
+                masterTransportTracker.awaitConfigureWorkers(generation, tableNames);
+                if (generation.isClosed()) {
+                    masterTransport.setGenerationFullyConsumed(generation);
+                }
+            }
+        }
+    }
+
+    private static Timestamp mockTimestamp(long minutesAfterEpoch) {
+        // Minutes to milliseconds:
+        return new Timestamp(new Date(minutesAfterEpoch * 60 * 1000));
     }
 
     private void awaitInvocationIncrease(Supplier<Integer> invocationCount, int awaitingCount) {

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/master/MasterThread.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/master/MasterThread.java
@@ -5,6 +5,7 @@ import com.scylladb.cdc.cql.MasterCQL;
 import com.scylladb.cdc.model.TableName;
 import com.scylladb.cdc.transport.MasterTransport;
 
+import java.time.Clock;
 import java.util.Set;
 
 import static org.junit.jupiter.api.Assertions.fail;
@@ -26,7 +27,11 @@ public class MasterThread implements AutoCloseable {
     }
 
     public MasterThread(MasterTransport masterTransport, MasterCQL masterCQL, Set<TableName> tableNames) {
-        this(new Connectors(masterTransport, masterCQL, tableNames,
+        this(masterTransport, masterCQL, tableNames, Clock.systemDefaultZone());
+    }
+
+    public MasterThread(MasterTransport masterTransport, MasterCQL masterCQL, Set<TableName> tableNames, Clock clock) {
+        this(new Connectors(masterTransport, masterCQL, tableNames, clock,
                 DEFAULT_SLEEP_BEFORE_FIRST_GENERATION_MS, DEFAULT_SLEEP_BEFORE_GENERATION_DONE_MS, DEFAULT_SLEEP_AFTER_EXCEPTION_MS));
     }
 

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/master/MockGenerationMetadata.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/master/MockGenerationMetadata.java
@@ -7,16 +7,6 @@ import java.nio.ByteBuffer;
 import java.util.*;
 
 public class MockGenerationMetadata {
-
-    public static GenerationMetadata mockGenerationMetadata(long start, Optional<Long> end, int vnodeCount) {
-        // Scale start, end to minutes.
-        final long TIMESTAMP_SCALING = 1000 * 60;
-        start = start * TIMESTAMP_SCALING;
-        end = end.map(e -> e * TIMESTAMP_SCALING);
-
-        return mockGenerationMetadata(new Timestamp(new Date(start)), end.map(Date::new).map(Timestamp::new), vnodeCount);
-    }
-
     public static GenerationMetadata mockGenerationMetadata(Timestamp start, Optional<Timestamp> end, int vnodeCount) {
         // Random with deterministic seed
         Random random = new Random(start.toDate().getTime());

--- a/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnector.java
+++ b/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnector.java
@@ -21,6 +21,7 @@ import org.apache.kafka.connect.source.SourceConnector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.time.Clock;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -66,7 +67,7 @@ public class ScyllaConnector extends SourceConnector {
         Driver3MasterCQL cql = new Driver3MasterCQL(masterSession);
         this.masterTransport = new ScyllaMasterTransport(context(), new SourceInfo(connectorConfig));
         Set<TableName> tableNames = connectorConfig.getTableNames();
-        Connectors connectors = new Connectors(masterTransport, cql, tableNames,
+        Connectors connectors = new Connectors(masterTransport, cql, tableNames, Clock.systemDefaultZone(),
                 DEFAULT_SLEEP_BEFORE_FIRST_GENERATION_MS, DEFAULT_SLEEP_BEFORE_GENERATION_DONE_MS, DEFAULT_SLEEP_AFTER_EXCEPTION_MS);
         Master master = new Master(connectors);
 

--- a/scylla-cdc-lib/src/main/java/com/scylladb/cdc/lib/MasterThread.java
+++ b/scylla-cdc-lib/src/main/java/com/scylladb/cdc/lib/MasterThread.java
@@ -1,5 +1,6 @@
 package com.scylladb.cdc.lib;
 
+import java.time.Clock;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -25,7 +26,7 @@ public final class MasterThread extends Thread {
         Preconditions.checkNotNull(cql);
         Preconditions.checkNotNull(tables);
         Preconditions.checkArgument(!tables.isEmpty());
-        Connectors connectors = new Connectors(transport, cql, tables,
+        Connectors connectors = new Connectors(transport, cql, tables, Clock.systemDefaultZone(),
                 DEFAULT_SLEEP_BEFORE_FIRST_GENERATION_MS, DEFAULT_SLEEP_BEFORE_GENERATION_DONE_MS, DEFAULT_SLEEP_AFTER_EXCEPTION_MS);
         this.master = new Master(connectors);
     }


### PR DESCRIPTION
Add skipping of old generations, based on tables TTL value. For example, if there is a generation which ended 5 days ago, but our CDC table has 1 day TTL, we can safely skip reading this generation. 

Partially mitigates #1. (To fully mitigate this issue, skipping is not enough - we have to trim generations, as they could be very long).