### PR TITLE
Add support for new streams/generations tables (v2)

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3MasterCQL.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/driver3/Driver3MasterCQL.java
@@ -7,10 +7,13 @@ import static com.datastax.driver.core.querybuilder.QueryBuilder.gt;
 import static com.datastax.driver.core.querybuilder.QueryBuilder.select;
 
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Date;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
 import com.datastax.driver.core.BoundStatement;
 import com.datastax.driver.core.ConsistencyLevel;
@@ -20,32 +23,168 @@ import com.datastax.driver.core.ResultSet;
 import com.datastax.driver.core.ResultSetFuture;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.Statement;
 import com.google.common.base.Preconditions;
+import com.google.common.flogger.FluentLogger;
 import com.google.common.util.concurrent.FutureCallback;
 import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
 import com.scylladb.cdc.cql.BaseMasterCQL;
+import com.scylladb.cdc.model.FutureUtils;
 
 public final class Driver3MasterCQL extends BaseMasterCQL {
+    private static final FluentLogger logger = FluentLogger.forEnclosingClass();
 
     private final Session session;
-    private final PreparedStatement fetchSmallestGenerationAfterStmt;
-    private final PreparedStatement fetchStreamsStmt;
+
+    // (Streams description table V2)
+    //
+    // PreparedStatements for querying in clusters with
+    // system_distributed.cdc_generation_timestamps
+    // and system_distributed.cdc_streams_descriptions_v2 tables.
+    private PreparedStatement fetchSmallestGenerationAfterStmt;
+    private PreparedStatement fetchStreamsStmt;
+    private boolean foundRewritten = false;
+
+    // (Streams description table V1)
+    //
+    // PreparedStatements for querying in clusters WITHOUT
+    // system_distributed.cdc_generation_timestamps
+    // and system_distributed.cdc_streams_descriptions_v2 tables.
+    private PreparedStatement legacyFetchSmallestGenerationAfterStmt;
+    private PreparedStatement legacyFetchStreamsStmt;
 
     public Driver3MasterCQL(Session session) {
         Preconditions.checkNotNull(session);
         this.session = session;
-        fetchSmallestGenerationAfterStmt = session.prepare(getFetchSmallestGenerationAfter());
-        fetchStreamsStmt = session.prepare(getFetchStreams());
     }
 
-    private static RegularStatement getFetchSmallestGenerationAfter() {
-        return select().min(column("time")).from("system_distributed", "cdc_streams_descriptions")
-                .where(gt("time", bindMarker())).allowFiltering();
+    private CompletableFuture<Boolean> fetchShouldQueryLegacyTables() {
+        // Decide if we should query "Streams description table V1" (legacy)
+
+        boolean hasNewTables = session.getCluster().getMetadata().getKeyspace("system_distributed")
+                .getTable("cdc_generation_timestamps") != null;
+        boolean hasLegacyTables = session.getCluster().getMetadata().getKeyspace("system_distributed")
+                .getTable("cdc_streams_descriptions") != null;
+
+        // Simple cases when there are only
+        // tables from one version:
+
+        if (hasLegacyTables && !hasNewTables) {
+            logger.atFine().log("Using legacy (V1) streams description table, as a newer (V2) table was not found.");
+            return CompletableFuture.completedFuture(true);
+        }
+
+        if (!hasLegacyTables && hasNewTables) {
+            logger.atFine().log("Using new (V2) streams description table, as a legacy (V1) table was not found.");
+            return CompletableFuture.completedFuture(false);
+        }
+
+        if (!hasLegacyTables && !hasNewTables) {
+            // No stream description tables found!
+            CompletableFuture<Boolean> exceptionalFuture = new CompletableFuture<>();
+            exceptionalFuture.completeExceptionally(new IllegalStateException("Could not find any Scylla CDC stream " +
+                    "description tables (either streams description table V1 or V2). Make sure you have Scylla CDC enabled."));
+            return exceptionalFuture;
+        }
+
+        // By now we know that there are both "Streams description table V1"
+        // and "Streams description table V2" present in the cluster.
+        //
+        // We should use "Streams description table V2" only after a
+        // rewrite has completed:
+        // https://github.com/scylladb/scylla/blob/master/docs/design-notes/cdc.md#streams-description-table-v1-and-rewriting
+
+        if (foundRewritten) {
+            // If we found a "rewritten" row, that means that
+            // we can use the "Streams description table V2".
+            logger.atFiner().log("Using new (V2) streams description table, because a 'rewritten' row was found previously.");
+            return CompletableFuture.completedFuture(false);
+        }
+
+        // We haven't seen a rewritten row yet. Do a query
+        // to check if it exists now.
+
+        return executeOne(getFetchRewritten()).thenApply(fetchedRewritten -> {
+            if (fetchedRewritten.isPresent()) {
+                // There is a "rewritten" row.
+                foundRewritten = true;
+                logger.atInfo().log("Found a 'rewritten' row. Will use new (V2) streams description table from now on.");
+                return false;
+            } else {
+                logger.atWarning().log("Using legacy (V1) streams description table, even though newer (V2) table was found, but " +
+                        "a 'rewritten' row is still missing. This might mean that the rewriting process is still pending or you have " +
+                        "disabled streams description rewriting - in that case the library will not switch to the new (V2) table " +
+                        "until it discovers a 'rewritten' row. Read more at: " +
+                        "https://github.com/scylladb/scylla/blob/master/docs/design-notes/cdc.md#streams-description-table-v1-and-rewriting");
+                return true;
+            }
+        });
     }
 
-    private static RegularStatement getFetchStreams() {
-        return select().column("streams").from("system_distributed", "cdc_streams_descriptions")
-                .where(eq("time", bindMarker())).allowFiltering();
+    private CompletableFuture<PreparedStatement> getLegacyFetchSmallestGenerationAfter() {
+        if (legacyFetchSmallestGenerationAfterStmt != null) {
+            return CompletableFuture.completedFuture(legacyFetchSmallestGenerationAfterStmt);
+        } else {
+            ListenableFuture<PreparedStatement> prepareStatement = session.prepareAsync(
+                    select().min(column("time")).from("system_distributed", "cdc_streams_descriptions")
+                            .where(gt("time", bindMarker())).allowFiltering()
+            );
+            return FutureUtils.convert(prepareStatement).thenApply(preparedStatement -> {
+                legacyFetchSmallestGenerationAfterStmt = preparedStatement;
+                return preparedStatement;
+            });
+        }
+    }
+
+    private CompletableFuture<PreparedStatement> getFetchSmallestGenerationAfter() {
+        if (fetchSmallestGenerationAfterStmt != null) {
+            return CompletableFuture.completedFuture(fetchSmallestGenerationAfterStmt);
+        } else {
+            ListenableFuture<PreparedStatement> prepareStatement = session.prepareAsync(
+                    select().min(column("time")).from("system_distributed", "cdc_generation_timestamps")
+                            .where(eq("key", "timestamps")).and(gt("time", bindMarker()))
+            );
+            return FutureUtils.convert(prepareStatement).thenApply(preparedStatement -> {
+                fetchSmallestGenerationAfterStmt = preparedStatement;
+                return preparedStatement;
+            });
+        }
+    }
+
+    private CompletableFuture<PreparedStatement> getLegacyFetchStreams() {
+        if (legacyFetchStreamsStmt != null) {
+            return CompletableFuture.completedFuture(legacyFetchStreamsStmt);
+        } else {
+            ListenableFuture<PreparedStatement> prepareStatement = session.prepareAsync(
+                    select().column("streams").from("system_distributed", "cdc_streams_descriptions")
+                            .where(eq("time", bindMarker())).allowFiltering()
+            );
+            return FutureUtils.convert(prepareStatement).thenApply(preparedStatement -> {
+                legacyFetchStreamsStmt = preparedStatement;
+                return preparedStatement;
+            });
+        }
+    }
+
+    private CompletableFuture<PreparedStatement> getFetchStreams() {
+        if (fetchStreamsStmt != null) {
+            return CompletableFuture.completedFuture(fetchStreamsStmt);
+        } else {
+            ListenableFuture<PreparedStatement> prepareStatement = session.prepareAsync(
+                    select().column("streams").from("system_distributed", "cdc_streams_descriptions_v2")
+                            .where(eq("time", bindMarker()))
+            );
+            return FutureUtils.convert(prepareStatement).thenApply(preparedStatement -> {
+                fetchStreamsStmt = preparedStatement;
+                return preparedStatement;
+            });
+        }
+    }
+
+    private Statement getFetchRewritten() {
+        return select().from("system", "cdc_local")
+                .where(eq("key", "rewritten"));
     }
 
     private ConsistencyLevel computeCL() {
@@ -53,7 +192,7 @@ public final class Driver3MasterCQL extends BaseMasterCQL {
                 : ConsistencyLevel.ONE;
     }
 
-    private void consumeResult(ResultSet rs, CompletableFuture<Optional<Row>> result) {
+    private void consumeOneResult(ResultSet rs, CompletableFuture<Optional<Row>> result) {
         int availCount = rs.getAvailableWithoutFetching();
         if (availCount == 0) {
             if (rs.isFullyFetched()) {
@@ -63,7 +202,7 @@ public final class Driver3MasterCQL extends BaseMasterCQL {
 
                     @Override
                     public void onSuccess(ResultSet rs) {
-                        consumeResult(rs, result);
+                        consumeOneResult(rs, result);
                     }
 
                     @Override
@@ -78,14 +217,60 @@ public final class Driver3MasterCQL extends BaseMasterCQL {
         }
     }
 
-    private CompletableFuture<Optional<Row>> execute(BoundStatement stmt) {
+    private void consumeManyResults(ResultSet rs, Collection<Row> alreadyFetched,
+                                    CompletableFuture<Collection<Row>> result) {
+        int availableWithoutFetching = rs.getAvailableWithoutFetching();
+        if (availableWithoutFetching == 0) {
+            if (rs.isFullyFetched()) {
+                result.complete(alreadyFetched);
+            } else {
+                Futures.addCallback(rs.fetchMoreResults(), new FutureCallback<ResultSet>() {
+
+                    @Override
+                    public void onSuccess(ResultSet rsNew) {
+                        consumeManyResults(rsNew, alreadyFetched, result);
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        result.completeExceptionally(t);
+                    }
+                });
+            }
+        } else {
+            for (int i = 0; i < availableWithoutFetching; i++) {
+                alreadyFetched.add(rs.one());
+            }
+            consumeManyResults(rs, alreadyFetched, result);
+        }
+    }
+
+    private CompletableFuture<Optional<Row>> executeOne(Statement stmt) {
         CompletableFuture<Optional<Row>> result = new CompletableFuture<>();
         ResultSetFuture future = session.executeAsync(stmt.setConsistencyLevel(computeCL()));
         Futures.addCallback(future, new FutureCallback<ResultSet>() {
 
             @Override
             public void onSuccess(ResultSet rs) {
-                consumeResult(rs, result);
+                consumeOneResult(rs, result);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                result.completeExceptionally(t);
+            }
+        });
+        return result;
+    }
+
+    private CompletableFuture<Collection<Row>> executeMany(Statement stmt) {
+        CompletableFuture<Collection<Row>> result = new CompletableFuture<>();
+        ResultSetFuture future = session.executeAsync(stmt.setConsistencyLevel(computeCL()));
+        Futures.addCallback(future, new FutureCallback<ResultSet>() {
+
+            @Override
+            public void onSuccess(ResultSet rs) {
+                consumeManyResults(rs, new ArrayList<>(), result);
             }
 
             @Override
@@ -98,12 +283,28 @@ public final class Driver3MasterCQL extends BaseMasterCQL {
 
     @Override
     protected CompletableFuture<Optional<Date>> fetchSmallestGenerationAfter(Date after) {
-        return execute(fetchSmallestGenerationAfterStmt.bind(after)).thenApply(o -> o.map(r -> r.getTimestamp(0)));
+        return fetchShouldQueryLegacyTables().thenCompose(shouldQueryLegacyTables -> {
+            if (shouldQueryLegacyTables) {
+                return getLegacyFetchSmallestGenerationAfter().thenCompose(statement ->
+                        executeOne(statement.bind(after)).thenApply(o -> o.map(r -> r.getTimestamp(0))));
+            } else {
+                return getFetchSmallestGenerationAfter().thenCompose(statement ->
+                        executeOne(statement.bind(after)).thenApply(o -> o.map(r -> r.getTimestamp(0))));
+            }
+        });
     }
 
     @Override
     protected CompletableFuture<Set<ByteBuffer>> fetchStreamsForGeneration(Date generationStart) {
-        return execute(fetchStreamsStmt.bind(generationStart)).thenApply(o -> o.get().getSet(0, ByteBuffer.class));
+        return fetchShouldQueryLegacyTables().thenCompose(shouldQueryLegacyTables -> {
+            if (shouldQueryLegacyTables) {
+                return getLegacyFetchStreams().thenCompose(statement ->
+                        executeOne(statement.bind(generationStart)).thenApply(o -> o.get().getSet(0, ByteBuffer.class)));
+            } else {
+                return getFetchStreams().thenCompose(statement -> executeMany(statement.bind(generationStart))
+                        .thenApply(o -> o.stream().flatMap(r -> r.getSet(0, ByteBuffer.class).stream()).collect(Collectors.toSet())));
+            }
+        });
     }
 
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/FutureUtils.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/FutureUtils.java
@@ -1,5 +1,9 @@
 package com.scylladb.cdc.model;
 
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
@@ -30,5 +34,22 @@ public final class FutureUtils {
                 return exceptionally.apply(wrapper.throwable);
             }
         });
+    }
+
+    public static <T> CompletableFuture<T> convert(ListenableFuture<T> fut) {
+        CompletableFuture<T> result = new CompletableFuture<>();
+        Futures.addCallback(fut, new FutureCallback<T>() {
+
+            @Override
+            public void onSuccess(T value) {
+                result.complete(value);
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                result.completeExceptionally(t);
+            }
+        });
+        return result;
     }
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/master/Master.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/master/Master.java
@@ -103,6 +103,7 @@ public final class Master {
                     generation = getNextGeneration(generation);
                     tasks = createTasks(generation);
                 }
+                logger.atInfo().log("Master found a new generation: %s. Will call transport.configureWorkers().", generation.getId());
                 connectors.transport.configureWorkers(tasks);
                 while (!generationDone(generation, tasks.keySet())) {
                     Thread.sleep(connectors.sleepBeforeGenerationDoneMs);


### PR DESCRIPTION
Add support for new stream/generations tables.

The new format was introduced in this PR:
https://github.com/scylladb/scylla/pull/8018

The new behavior of the library is first to check if both new tables (streams description table v2) and legacy tables (v1) are present.

- If only the new table is present, that table is used.
- If only the legacy table is present, that table is used.
- If both are present, we check if generations have been rewritten into the new table, by querying the `system.cdc_local` table and finding the "rewritten" row.

Note that if someone has disabled rewriting (cdc_dont_rewrite_streams), the Master will not use the new tables until a rewritten row is inserted (potentially manually in that case).

I have done the following testing: 
1. Started a 2-node cluster of Scylla 4.3.0. 
2. Created a CDC-enabled table.
3. Started a Printer example application, reading from that table (this application turned on the entire time - up to point 11).
4. Inserted some data and verified it was correctly received by the Printer.
5. Added a 3rd node of Scylla 4.3.0.
6. After new generation started, inserted some data and verified it was correctly received by the Printer.
7. Performed a rolling upgrade to Scylla 4.5.dev-0.20210301.ef97adc72.
8. Verified (debug prints) that the Printer switched to reading rewritten table.
9. Inserted some data and verified it was correctly received by the Printer.
10. Added a 4th node of Scylla 4.5.dev-0.20210301.ef97adc72.
11. Inserted some data and verified it was correctly received by the Printer.