### PR TITLE
Revamp SourceInfo and fix timestamps

### DIFF
--- a/scylla-cdc-kafka-connect/README.md
+++ b/scylla-cdc-kafka-connect/README.md
@@ -122,8 +122,12 @@ Data change event's value consists of a schema and a payload section. The payloa
 - `op`: type of operation. `c` for `INSERT`, `u` for `UPDATE`, `d` for `DELETE`.
 - `before`: an optional field with state of the row before the event occurred. Present in `DELETE` data change events.
 - `after`: an optional field with state of the row after the event occurred. Present in `UPDATE` and `INSERT` data change events.
-- `source`: metadata about the source of event.
 - `ts_ms`: time at which connector processed the event.
+- `source`: metadata about the source of event:
+    - `name`: logical name of Scylla cluster (`scylla.name`).
+    - `ts_ms`: the time that the change was made in the database (in milliseconds). You can compute a difference between `source.ts_ms` and (top-level) `ts_ms` to determine the lag between the source Scylla change and the connector.
+    - `ts_us`: the time that the change was made in the database (in microseconds).
+    - `keyspace_name`, `table_name`: the name of keyspace and table this data change event originated from. 
 
 #### Cell representation
 Operations in Scylla, such as `INSERT` or `UPDATE`, do not have to modify all columns of a row. To differentiate between non-modification of column and inserting/updating `NULL`, all non-primary-key columns are wrapped with structure containing a single `value` field. For example, given this Scylla table and `UPDATE` operation:
@@ -207,6 +211,11 @@ The connector will generate the following data change event's value (with JSON s
             "type": "int64",
             "optional": false,
             "field": "ts_ms"
+          },
+          {
+            "type": "int64",
+            "optional": false,
+            "field": "ts_us"
           },
           {
             "type": "string",
@@ -343,6 +352,7 @@ The connector will generate the following data change event's value (with JSON s
       "connector": "scylla",
       "name": "MyScyllaCluster",
       "ts_ms": 1611578778701,
+      "ts_us": 1611578778701813,
       "snapshot": "false",
       "db": "ks",
       "keyspace_name": "ks",
@@ -384,6 +394,7 @@ The connector will generate the following data change event's value (with JSON s
       "connector": "scylla",
       "name": "MyScyllaCluster",
       "ts_ms": 1611578808701,
+      "ts_us": 1611578808701321,
       "snapshot": "false",
       "db": "ks",
       "keyspace_name": "ks",
@@ -414,6 +425,7 @@ Data change event's value for the second `UPDATE`:
       "connector": "scylla",
       "name": "MyScyllaCluster",
       "ts_ms": 1611578808701,
+      "ts_us": 1611578808701341,
       "snapshot": "false",
       "db": "ks",
       "keyspace_name": "ks",
@@ -454,6 +466,7 @@ The connector will generate the following data change event's value (with JSON s
       "connector": "scylla",
       "name": "MyScyllaCluster",
       "ts_ms": 1611578808701,
+      "ts_us": 1611578808701919,
       "snapshot": "false",
       "db": "ks",
       "keyspace_name": "ks",

--- a/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangesConsumer.java
+++ b/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaChangesConsumer.java
@@ -28,8 +28,11 @@ public class ScyllaChangesConsumer implements TaskAndRawChangeConsumer {
 
     @Override
     public CompletableFuture<Void> consume(Task task, RawChange change) {
-        TaskStateOffsetContext taskStateOffsetContext = offsetContext.taskStateOffsetContext(task.id);
         try {
+            Task updatedTask = task.updateState(change.getId());
+            TaskStateOffsetContext taskStateOffsetContext = offsetContext.taskStateOffsetContext(task.id);
+            taskStateOffsetContext.dataChangeEvent(updatedTask.state);
+
             RawChange.OperationType operationType = change.getOperationType();
             ChangeSchema changeSchema = change.getSchema();
             if (operationType == RawChange.OperationType.PARTITION_DELETE) {

--- a/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnector.java
+++ b/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnector.java
@@ -56,7 +56,7 @@ public class ScyllaConnector extends SourceConnector {
     private Master buildMaster(ScyllaConnectorConfig connectorConfig) {
         this.masterSession = new ScyllaSessionBuilder(connectorConfig).build();
         Driver3MasterCQL cql = new Driver3MasterCQL(masterSession);
-        this.masterTransport = new ScyllaMasterTransport(context(), new SourceInfo(connectorConfig));
+        this.masterTransport = new ScyllaMasterTransport(context(), connectorConfig);
         Set<TableName> tableNames = connectorConfig.getTableNames();
         MasterConfiguration masterConfiguration = MasterConfiguration.builder()
                 .withTransport(masterTransport)

--- a/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaMasterTransport.java
+++ b/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaMasterTransport.java
@@ -25,12 +25,12 @@ public class ScyllaMasterTransport implements MasterTransport {
 
     private final Logger logger = LoggerFactory.getLogger(getClass());
     private final SourceConnectorContext context;
-    private final SourceInfo sourceInfo;
+    private final ScyllaConnectorConfig connectorConfig;
     private volatile Map<TaskId, SortedSet<StreamId>> currentWorkerConfigurations;
 
-    public ScyllaMasterTransport(SourceConnectorContext context, SourceInfo sourceInfo) {
+    public ScyllaMasterTransport(SourceConnectorContext context, ScyllaConnectorConfig connectorConfig) {
         this.context = context;
-        this.sourceInfo = sourceInfo;
+        this.connectorConfig = connectorConfig;
     }
 
     @Override
@@ -44,7 +44,7 @@ public class ScyllaMasterTransport implements MasterTransport {
         OffsetStorageReader reader = context.offsetStorageReader();
 
         List<Map<String, String>> partitions = tasks.stream()
-                .map(sourceInfo::partition)
+                .map(taskId -> new SourceInfo(connectorConfig, taskId).partition())
                 .collect(Collectors.toList());
 
         Collection<Map<String, Object>> offsets = reader.offsets(partitions).values();

--- a/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaOffsetContext.java
+++ b/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaOffsetContext.java
@@ -8,21 +8,20 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.Struct;
 
 import java.time.Instant;
-import java.util.Date;
 import java.util.Map;
 
 public class ScyllaOffsetContext implements OffsetContext {
 
-    private final SourceInfo sourceInfo;
+    private final Map<TaskId, SourceInfo> sourceInfos;
     private final TransactionContext transactionContext;
 
-    public ScyllaOffsetContext(SourceInfo sourceInfo, TransactionContext transactionContext) {
-        this.sourceInfo = sourceInfo;
+    public ScyllaOffsetContext(Map<TaskId, SourceInfo> sourceInfos, TransactionContext transactionContext) {
+        this.sourceInfos = sourceInfos;
         this.transactionContext = transactionContext;
     }
 
     public TaskStateOffsetContext taskStateOffsetContext(TaskId taskId) {
-        return new TaskStateOffsetContext(this, taskId, sourceInfo);
+        return new TaskStateOffsetContext(this, sourceInfos.get(taskId));
     }
 
     @Override
@@ -39,12 +38,14 @@ public class ScyllaOffsetContext implements OffsetContext {
 
     @Override
     public Schema getSourceInfoSchema() {
-        return sourceInfo.schema();
+        // See TaskStateOffsetContext
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public Struct getSourceInfo() {
-        return sourceInfo.struct();
+        // See TaskStateOffsetContext
+        throw new UnsupportedOperationException();
     }
 
     @Override
@@ -74,8 +75,7 @@ public class ScyllaOffsetContext implements OffsetContext {
 
     @Override
     public void event(DataCollectionId dataCollectionId, Instant instant) {
-        // Not used by the scylla connector
-        // See TaskStateOffsetContext
+        // Not used by the Scylla CDC Source Connector.
         throw new UnsupportedOperationException();
     }
 

--- a/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaSourceInfoStructMaker.java
+++ b/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaSourceInfoStructMaker.java
@@ -7,6 +7,7 @@ import org.apache.kafka.connect.data.Struct;
 
 public class ScyllaSourceInfoStructMaker extends AbstractSourceInfoStructMaker<SourceInfo> {
 
+    private static final String TS_US = "ts_us";
     private final Schema schema;
 
     public ScyllaSourceInfoStructMaker(String connector, String version, CommonConnectorConfig connectorConfig) {
@@ -15,6 +16,7 @@ public class ScyllaSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
                 .name("com.scylladb.cdc.debezium.connector")
                 .field(SourceInfo.KEYSPACE_NAME, Schema.STRING_SCHEMA)
                 .field(SourceInfo.TABLE_NAME, Schema.STRING_SCHEMA)
+                .field(TS_US, Schema.INT64_SCHEMA)
                 .build();
     }
 
@@ -27,6 +29,7 @@ public class ScyllaSourceInfoStructMaker extends AbstractSourceInfoStructMaker<S
     public Struct struct(SourceInfo sourceInfo) {
         return super.commonStruct(sourceInfo)
                 .put(SourceInfo.KEYSPACE_NAME, sourceInfo.getTableName().keyspace)
-                .put(SourceInfo.TABLE_NAME, sourceInfo.getTableName().name);
+                .put(SourceInfo.TABLE_NAME, sourceInfo.getTableName().name)
+                .put(TS_US, sourceInfo.timestampUs());
     }
 }

--- a/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaWorkerTransport.java
+++ b/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaWorkerTransport.java
@@ -37,8 +37,7 @@ public class ScyllaWorkerTransport implements WorkerTransport {
 
     @Override
     public void setState(TaskId task, TaskState newState) {
-        TaskStateOffsetContext taskStateOffsetContext = offsetContext.taskStateOffsetContext(task);
-        taskStateOffsetContext.dataChangeEvent(newState);
+        // Already handled in consume().
     }
 
     @Override

--- a/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/SourceInfo.java
+++ b/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/SourceInfo.java
@@ -4,6 +4,7 @@ import com.datastax.driver.core.utils.Bytes;
 import com.datastax.driver.core.utils.UUIDs;
 import com.scylladb.cdc.model.TableName;
 import com.scylladb.cdc.model.TaskId;
+import com.scylladb.cdc.model.worker.ChangeId;
 import com.scylladb.cdc.model.worker.TaskState;
 import io.debezium.connector.common.BaseSourceInfo;
 import io.debezium.util.Collect;
@@ -23,59 +24,58 @@ public class SourceInfo extends BaseSourceInfo {
     public static final String CHANGE_ID_STREAM_ID = "change_id_stream_id";
     public static final String CHANGE_ID_TIME = "change_id_time";
 
-    private TableName lastTableName;
-    private Instant lastTimestamp = new Date(0).toInstant();
+    private final TaskId taskId;
+    private TaskState taskState;
 
-    private final Map<TaskId, TaskState> taskStates = new HashMap<>();
-
-    protected SourceInfo(ScyllaConnectorConfig connectorConfig) {
+    protected SourceInfo(ScyllaConnectorConfig connectorConfig, TaskId taskId) {
         super(connectorConfig);
+        this.taskId = taskId;
     }
 
-    public Map<String, String> partition(TaskId taskId) {
+    public Map<String, String> partition() {
         return Collect.hashMapOf(KEYSPACE_NAME, taskId.getTable().keyspace,
                 TABLE_NAME, taskId.getTable().name, VNODE_ID, Long.toString(taskId.getvNodeId().getIndex()),
                 GENERATION_START, Long.toString(taskId.getGenerationId().getGenerationStart().toDate().getTime()));
     }
 
-    public Map<String, String> offset(TaskId taskId) {
-        TaskState position = getTaskState(taskId);
-        Map<String, String> result = Collect.hashMapOf(WINDOW_START, position.getWindowStart().toString(),
-                WINDOW_END, position.getWindowEnd().toString());
-        position.getLastConsumedChangeId().ifPresent(changeId -> {
+    public Map<String, String> offset() {
+        Map<String, String> result = Collect.hashMapOf(WINDOW_START, taskState.getWindowStart().toString(),
+                WINDOW_END, taskState.getWindowEnd().toString());
+        taskState.getLastConsumedChangeId().ifPresent(changeId -> {
             result.putAll(Collect.hashMapOf(CHANGE_ID_STREAM_ID, Bytes.toHexString(changeId.getStreamId().getValue()),
                     CHANGE_ID_TIME, changeId.getChangeTime().getUUID().toString()));
         });
         return result;
     }
 
-    public TaskState getTaskState(TaskId taskId) {
-        return taskStates.get(taskId);
+    public TaskState getTaskState() {
+        return taskState;
     }
 
-    public void setTaskState(TaskId taskId, TaskState taskState) {
-        taskStates.put(taskId, taskState);
-        lastTableName = taskId.getTable();
-        // TODO - set the timestamp based on cdc$time column, not window
-        lastTimestamp = new Date(UUIDs.unixTimestamp(taskState.getWindowStart())).toInstant();
+    public void setTaskState(TaskState taskState) {
+        this.taskState = taskState;
     }
 
-    public void dataChangeEvent(TaskId taskId, TaskState taskState) {
-        setTaskState(taskId, taskState);
+    public void dataChangeEvent(TaskState taskState) {
+        setTaskState(taskState);
     }
 
     public TableName getTableName() {
-        return lastTableName;
+        return taskId.getTable();
     }
 
     @Override
     protected Instant timestamp() {
-        return lastTimestamp;
+        return taskState.getLastConsumedChangeId().get().getChangeTime().getDate().toInstant();
+    }
+
+    public long timestampUs() {
+        return taskState.getLastConsumedChangeId().get().getChangeTime().getTimestamp();
     }
 
     @Override
     protected String database() {
         // TODO - database() is required by Debezium. Currently returning the keyspace name.
-        return lastTableName.keyspace;
+        return getTableName().keyspace;
     }
 }

--- a/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/TaskStateOffsetContext.java
+++ b/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/TaskStateOffsetContext.java
@@ -12,77 +12,75 @@ import java.time.Instant;
 import java.util.Map;
 
 public class TaskStateOffsetContext implements OffsetContext {
-
-    private final ScyllaOffsetContext offsetContext;
-    private final TaskId taskId;
+    private final ScyllaOffsetContext scyllaOffsetContext;
     private final SourceInfo sourceInfo;
 
-    public TaskStateOffsetContext(ScyllaOffsetContext offsetContext, TaskId taskId, SourceInfo sourceInfo) {
-        this.offsetContext = offsetContext;
-        this.taskId = taskId;
+    public TaskStateOffsetContext(ScyllaOffsetContext scyllaOffsetContext, SourceInfo sourceInfo) {
+        this.scyllaOffsetContext = scyllaOffsetContext;
         this.sourceInfo = sourceInfo;
     }
 
     @Override
     public Map<String, ?> getPartition() {
-        return sourceInfo.partition(taskId);
+        return sourceInfo.partition();
     }
 
     @Override
     public Map<String, ?> getOffset() {
-        return sourceInfo.offset(taskId);
+        return sourceInfo.offset();
     }
 
     public TaskState getTaskState() {
-        return sourceInfo.getTaskState(taskId);
+        return sourceInfo.getTaskState();
     }
 
     public void dataChangeEvent(TaskState taskState) {
-        sourceInfo.dataChangeEvent(taskId, taskState);
+        sourceInfo.dataChangeEvent(taskState);
     }
 
     @Override
     public Schema getSourceInfoSchema() {
-        return offsetContext.getSourceInfoSchema();
+        return sourceInfo.schema();
     }
 
     @Override
     public Struct getSourceInfo() {
-        return offsetContext.getSourceInfo();
+        return sourceInfo.struct();
     }
 
     @Override
     public boolean isSnapshotRunning() {
-        return offsetContext.isSnapshotRunning();
+        throw new UnsupportedOperationException();
     }
 
     @Override
     public void markLastSnapshotRecord() {
-        offsetContext.markLastSnapshotRecord();
+
     }
 
     @Override
     public void preSnapshotStart() {
-        offsetContext.preSnapshotStart();
+
     }
 
     @Override
     public void preSnapshotCompletion() {
-        offsetContext.preSnapshotCompletion();
+
     }
 
     @Override
     public void postSnapshotCompletion() {
-        offsetContext.postSnapshotCompletion();
+
     }
 
     @Override
     public void event(DataCollectionId dataCollectionId, Instant instant) {
+        // Not used by the Scylla CDC Source Connector.
         throw new UnsupportedOperationException();
     }
 
     @Override
     public TransactionContext getTransactionContext() {
-        return offsetContext.getTransactionContext();
+        return scyllaOffsetContext.getTransactionContext();
     }
 }


### PR DESCRIPTION
Before this change, `source.ts_ms` field in generated Kafka messages by the connector contained the end of window timestamp instead of individual message timestamp. This change makes this value correctly filled in (the `cdc$time` of particular message).

Firstly, Task offset is now modified in `consume()`, instead of `setState()` (`setState()` is triggered after `consume()`).

Secondly, I modified what `SourceInfo` object represents. This object is a Debezium object, which contains the information about a specific source (and its offset). Previously, there was a single SourceInfo object, which stored offset state about all Tasks. That single object was shared between different Tasks, but Debezium expects a single "last timestamp" from SourceInfo, making it impossible to return the correct "last timestamp" (you would have to provide a TaskId information, but Debezium subsystems don't have this).

The solution is to build 1 SourceInfo per each Task (not a single global SourceInfo).

Because within a single Task (vnode) all operations made by the library are correctly ordered, we can set the proper "last timestamp" value in SourceInfo (now one per Task).