### PR TITLE
Trim initial tasks according to TTL

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/WorkerCQL.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/WorkerCQL.java
@@ -17,4 +17,6 @@ public interface WorkerCQL {
     void prepare(Set<TableName> tables) throws InterruptedException, ExecutionException;
 
     CompletableFuture<Reader> createReader(Task task);
+
+    CompletableFuture<Optional<Long>> fetchTableTTL(TableName tableName);
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/TaskState.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/TaskState.java
@@ -80,4 +80,21 @@ public final class TaskState {
         Timestamp generationStart = generation.getGenerationStart();
         return new TaskState(generationStart, generationStart.plus(windowSizeMs, ChronoUnit.MILLIS), Optional.empty());
     }
+
+    /* If the state is before |minimumWindowStart| then this method returns a state
+     * starting at |minimumWindowStart| and spanning for |windowSizeMs| milliseconds.
+     * Otherwise, the original state is returned. An intended use for |minimumWindowStart|
+     * is when you are sure that there aren't any changes before |minimumWindowStart|
+     * (for example due to TTL) and don't want to have a state that will span a range
+     * without any changes.
+     */
+    public TaskState trimTaskState(Timestamp minimumWindowStart, long windowSizeMs) {
+        // If the entire state is before minimumWindowStart,
+        // return a new state starting at minimumWindowStart.
+        if (this.windowEnd.compareTo(minimumWindowStart) < 0) {
+            return new TaskState(minimumWindowStart, minimumWindowStart.plus(windowSizeMs, ChronoUnit.MILLIS), Optional.empty());
+        }
+
+        return this;
+    }
 }

--- a/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3CommonCQL.java
+++ b/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3CommonCQL.java
@@ -1,0 +1,61 @@
+package com.scylladb.cdc.cql.driver3;
+
+import com.datastax.driver.core.KeyspaceMetadata;
+import com.datastax.driver.core.Metadata;
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.TableMetadata;
+import com.scylladb.cdc.model.FutureUtils;
+import com.scylladb.cdc.model.TableName;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+class Driver3CommonCQL {
+    protected static CompletableFuture<Optional<Long>> fetchTableTTL(Session session, TableName tableName) {
+        Metadata metadata = session.getCluster().getMetadata();
+        KeyspaceMetadata keyspaceMetadata = metadata.getKeyspace(tableName.keyspace);
+        if (keyspaceMetadata == null) {
+            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
+                    String.format("Could not fetch the metadata of keyspace %s.", tableName.keyspace)));
+        }
+
+        TableMetadata tableMetadata = keyspaceMetadata.getTable(tableName.name);
+        if (tableMetadata == null) {
+            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
+                    String.format("Could not fetch the metadata of table %s.%s.", tableName.keyspace, tableName.name)));
+        }
+
+        if (!tableMetadata.getOptions().isScyllaCDC()) {
+            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
+                    String.format("Table %s.%s does not have Scylla CDC enabled.", tableName.keyspace, tableName.name)));
+        }
+
+        Map<String, String> scyllaCDCOptions = tableMetadata.getOptions().getScyllaCDCOptions();
+        if (scyllaCDCOptions == null) {
+            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
+                    String.format("Table %s.%s does not have Scylla CDC metadata, " +
+                            "even though CDC is enabled.", tableName.keyspace, tableName.name)));
+        }
+
+        String ttl = scyllaCDCOptions.get("ttl");
+        if (ttl == null) {
+            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
+                    String.format("Table %s.%s does not have a TTL value in its metadata, " +
+                            "even though Scylla CDC is enabled and the metadata is present.", tableName.keyspace, tableName.name)));
+        }
+
+        try {
+            long parsedTTL = Long.parseLong(ttl);
+            if (parsedTTL == 0) {
+                // TTL is disabled.
+                return CompletableFuture.completedFuture(Optional.empty());
+            } else {
+                return CompletableFuture.completedFuture(Optional.of(parsedTTL));
+            }
+        } catch (NumberFormatException ex) {
+            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
+                    String.format("Table %s.%s has invalid TTL value: %s.", tableName.keyspace, tableName.name, ttl)));
+        }
+    }
+}

--- a/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3MasterCQL.java
+++ b/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3MasterCQL.java
@@ -312,50 +312,7 @@ public final class Driver3MasterCQL extends BaseMasterCQL {
 
     @Override
     public CompletableFuture<Optional<Long>> fetchTableTTL(TableName tableName) {
-        Metadata metadata = session.getCluster().getMetadata();
-        KeyspaceMetadata keyspaceMetadata = metadata.getKeyspace(tableName.keyspace);
-        if (keyspaceMetadata == null) {
-            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
-                    String.format("Could not fetch the metadata of keyspace %s.", tableName.keyspace)));
-        }
-
-        TableMetadata tableMetadata = keyspaceMetadata.getTable(tableName.name);
-        if (tableMetadata == null) {
-            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
-                    String.format("Could not fetch the metadata of table %s.%s.", tableName.keyspace, tableName.name)));
-        }
-
-        if (!tableMetadata.getOptions().isScyllaCDC()) {
-            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
-                    String.format("Table %s.%s does not have Scylla CDC enabled.", tableName.keyspace, tableName.name)));
-        }
-
-        Map<String, String> scyllaCDCOptions = tableMetadata.getOptions().getScyllaCDCOptions();
-        if (scyllaCDCOptions == null) {
-            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
-                    String.format("Table %s.%s does not have Scylla CDC metadata, " +
-                            "even though CDC is enabled.", tableName.keyspace, tableName.name)));
-        }
-
-        String ttl = scyllaCDCOptions.get("ttl");
-        if (ttl == null) {
-            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
-                    String.format("Table %s.%s does not have a TTL value in its metadata, " +
-                            "even though Scylla CDC is enabled and the metadata is present.", tableName.keyspace, tableName.name)));
-        }
-
-        try {
-            long parsedTTL = Long.parseLong(ttl);
-            if (parsedTTL == 0) {
-                // TTL is disabled.
-                return CompletableFuture.completedFuture(Optional.empty());
-            } else {
-                return CompletableFuture.completedFuture(Optional.of(parsedTTL));
-            }
-        } catch (NumberFormatException ex) {
-            return FutureUtils.exceptionalFuture(new IllegalArgumentException(
-                    String.format("Table %s.%s has invalid TTL value: %s.", tableName.keyspace, tableName.name, ttl)));
-        }
+        return Driver3CommonCQL.fetchTableTTL(session, tableName);
     }
 
     @Override

--- a/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3WorkerCQL.java
+++ b/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3WorkerCQL.java
@@ -179,4 +179,8 @@ public final class Driver3WorkerCQL implements WorkerCQL {
         return query(stmt, task);
     }
 
+    @Override
+    public CompletableFuture<Optional<Long>> fetchTableTTL(TableName tableName) {
+        return Driver3CommonCQL.fetchTableTTL(session, tableName);
+    }
 }


### PR DESCRIPTION
**This PR is dependent on #20 (therefore this many commits - only the last two are related to this PR).**

Previously, initial tasks created for workers would start according to a generation start timestamp or previously saved offset.

The issue with that approach is that the generation start could be far back in the past. For example if someone had created a Scylla cluster one year ago and didn't do any topology change, the workers would read all windows in that one year, even though the TTL value is probably low (default is 24 hours).

This commit trims created task states with fetched TTL value.

Fixes #1