### PR TITLE
Gracefully shutdown TaskActionsQueue

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/DelayedFutureService.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/DelayedFutureService.java
@@ -1,0 +1,45 @@
+package com.scylladb.cdc.model.worker;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+class DelayedFutureService {
+    private static final int AWAIT_TIMEOUT_MS = 1000;
+
+    private final ScheduledExecutorService internalExecutor;
+    private final Set<CompletableFuture<Void>> scheduledFutures;
+
+    public DelayedFutureService() {
+        this.scheduledFutures = Collections.newSetFromMap(new ConcurrentHashMap<>());
+        this.internalExecutor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread t = new Thread(runnable);
+            t.setName("DelayedFutureServiceThreadFor" + Thread.currentThread().getName());
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    public CompletableFuture<Void> delayedFuture(long numberOfMilliseconds) {
+        CompletableFuture<Void> result = new CompletableFuture<>();
+        scheduledFutures.add(result);
+        internalExecutor.schedule(() -> {
+            result.complete(null);
+            scheduledFutures.remove(result);
+        }, numberOfMilliseconds, TimeUnit.MILLISECONDS);
+        return result;
+    }
+
+    public void stop() throws InterruptedException {
+        internalExecutor.shutdown();
+        internalExecutor.awaitTermination(AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+        for (CompletableFuture<Void> scheduledFuture : scheduledFutures) {
+            scheduledFuture.complete(null);
+        }
+    }
+}

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/TaskActionsQueue.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/TaskActionsQueue.java
@@ -3,9 +3,13 @@ package com.scylladb.cdc.model.worker;
 import com.google.common.flogger.FluentLogger;
 
 import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
-import java.util.logging.Level;
 
 public final class TaskActionsQueue {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
@@ -21,6 +25,9 @@ public final class TaskActionsQueue {
      */
     private static final int POLL_TIMEOUT_MS = 50;
 
+    private static final int JOIN_TIMEOUT_MS = 10 * 1000;
+    private static final int JOIN_POLL_MS = 100;
+
     /*
      * Using a thread-safe queue on purpose, as
      * new TaskActions may be added from different
@@ -30,9 +37,11 @@ public final class TaskActionsQueue {
      * thread and is allowed to block.
      */
     private final LinkedBlockingQueue<TaskAction> queue;
+    private final Set<CompletableFuture<Void>> runningFutures;
 
     public TaskActionsQueue(Collection<TaskAction> initialActions) {
         queue = new LinkedBlockingQueue<>(initialActions);
+        runningFutures = Collections.newSetFromMap(new ConcurrentHashMap<>());
     }
 
     /*
@@ -43,10 +52,47 @@ public final class TaskActionsQueue {
         TaskAction action = queue.poll(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 
         if (action != null) {
-            action.run().thenAccept(queue::add).exceptionally(ex -> {
+            CompletableFuture<Void> actionRunFuture = action.run().thenAccept(queue::add).exceptionally(ex -> {
                 logger.atSevere().withCause(ex).log("Unhandled exception in TaskActionsQueue.");
                 return null;
             });
+            runningFutures.add(actionRunFuture);
+            actionRunFuture.thenApply((ignored) -> {
+                runningFutures.remove(actionRunFuture);
+                return null;
+            });
+        }
+    }
+
+    public void join() {
+        long joinStartTime = System.currentTimeMillis();
+        long maximumJoinEndTime = joinStartTime + JOIN_TIMEOUT_MS;
+
+        // Awaiting for runningFutures to get empty, meaning
+        // all futures gracefully finished.
+        while (System.currentTimeMillis() < maximumJoinEndTime) {
+            if (runningFutures.isEmpty()) {
+                break;
+            }
+
+            try {
+                Thread.sleep(JOIN_POLL_MS);
+            } catch (InterruptedException e) {
+                // We have been interrupted. Exit immediately from
+                // the while loop!
+                break;
+            }
+        }
+
+        // Some futures might have not finished...
+        if (!runningFutures.isEmpty()) {
+            logger.atWarning().log("Could not gracefully finish all started tasks in Worker's TaskActionsQueue " +
+                    "(%d futures still left)", runningFutures.size());
+
+            // Cancel them!
+            for (CompletableFuture<Void> future : runningFutures) {
+                future.cancel(true);
+            }
         }
     }
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/Worker.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/Worker.java
@@ -108,6 +108,17 @@ public final class Worker {
                 // Ignore InterruptedException
             }
         }
+
+        // Stop all "sleeping" futures.
+        try {
+            workerConfiguration.delayedFutureService.stop();
+        } catch (InterruptedException e) {
+            // Ignore InterruptedException
+        }
+
+        // Wait for already started actions to gracefully
+        // finish.
+        actions.join();
     }
 
     /*

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/WorkerConfiguration.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/WorkerConfiguration.java
@@ -19,10 +19,13 @@ public final class WorkerConfiguration {
     public final long queryTimeWindowSizeMs;
     public final long confidenceWindowSizeMs;
 
-    public RetryBackoff workerRetryBackoff;
+    public final RetryBackoff workerRetryBackoff;
+
+    public final DelayedFutureService delayedFutureService;
 
     private WorkerConfiguration(WorkerTransport transport, WorkerCQL cql, TaskAndRawChangeConsumer consumer,
-                               long queryTimeWindowSizeMs, long confidenceWindowSizeMs, RetryBackoff workerRetryBackoff) {
+                               long queryTimeWindowSizeMs, long confidenceWindowSizeMs, RetryBackoff workerRetryBackoff,
+                                DelayedFutureService delayedFutureService) {
         this.transport = Preconditions.checkNotNull(transport);
         this.cql = Preconditions.checkNotNull(cql);
         this.consumer = Preconditions.checkNotNull(consumer);
@@ -31,6 +34,7 @@ public final class WorkerConfiguration {
         Preconditions.checkArgument(confidenceWindowSizeMs > 0);
         this.confidenceWindowSizeMs = confidenceWindowSizeMs;
         this.workerRetryBackoff = Preconditions.checkNotNull(workerRetryBackoff);
+        this.delayedFutureService = Preconditions.checkNotNull(delayedFutureService);
     }
 
     public static Builder builder() {
@@ -81,7 +85,7 @@ public final class WorkerConfiguration {
 
         public WorkerConfiguration build() {
             return new WorkerConfiguration(transport, cql, consumer,
-                    queryTimeWindowSizeMs, confidenceWindowSizeMs, workerRetryBackoff);
+                    queryTimeWindowSizeMs, confidenceWindowSizeMs, workerRetryBackoff, new DelayedFutureService());
         }
     }
 }


### PR DESCRIPTION
**This PR is dependent on #26 (therefore this many commits - only the last one is related to this PR).**

Previously, some started `Futures` in `TaskActionsQueue` were not properly finished in case of shutdown of `Worker`.

The core issue was that in `TaskActionsQueue` we run() `TaskActions`, which return a `CompleteableFuture`, but no one waited on that `Future` or checked its status.

The other issue was that sleeps generated by `ScheduledExecutorService` were not immediately stopped in case of `Worker` stop. One unwanted effect of this was that after we closed Driver3's Session, a few seconds later some `Futures` "sleeping" on that `Executor` would "wake up" and start to use recently closed Session, causing many exceptions.

This commit fixes the first issue by saving started `Futures` into a set of running `Futures`. Those `Futures` delete themselves from that set after they have finished running. When closing `TaskActionsQueue` we wait for this set to get empty (with some timeout).

This commit also adds `DelayedFutureService` which generates "sleeping" futures and allows to immediately complete them in case of shutdown (so that the shutdown is very quick).