### PR TITLE
Throttle moveStateToNextWindow heartbeats

### DIFF
--- a/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
+++ b/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorConfig.java
@@ -156,6 +156,10 @@ public class ScyllaConnectorConfig extends CommonConnectorConfig {
         return config.getInteger(ScyllaConnectorConfig.CONFIDENCE_WINDOW_SIZE);
     }
 
+    public long getHeartbeatIntervalMs() {
+        return config.getInteger(Heartbeat.HEARTBEAT_INTERVAL);
+    }
+
     @Override
     public String getContextName() {
         return "Scylla";

--- a/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
+++ b/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaStreamingChangeEventSource.java
@@ -42,7 +42,7 @@ public class ScyllaStreamingChangeEventSource implements StreamingChangeEventSou
     public void execute(ChangeEventSourceContext context) throws InterruptedException {
         Driver3Session session = new ScyllaSessionBuilder(configuration).build();
         Driver3WorkerCQL cql = new Driver3WorkerCQL(session);
-        ScyllaWorkerTransport workerTransport = new ScyllaWorkerTransport(context, offsetContext, dispatcher);
+        ScyllaWorkerTransport workerTransport = new ScyllaWorkerTransport(context, offsetContext, dispatcher, configuration.getHeartbeatIntervalMs());
         ScyllaChangesConsumer changeConsumer = new ScyllaChangesConsumer(dispatcher, offsetContext, schema, clock);
         WorkerConfiguration workerConfiguration = WorkerConfiguration.builder()
                 .withTransport(workerTransport)


### PR DESCRIPTION
Throttle moveStateToNextWindow() heartbeats according to  HEARTBEAT_INTERVAL configuration.

That means that (at most) every HEARTBEAT_INTERVAL ms, |vnode count| many heartbeats will be created, each signaling current progress for each vnode (Task).

Tested it with large `heartbeat.interval.ms` value (2 minutes) and verified that every 2 minutes new heartbeats were added (exactly |vnode count| many of them).

Verified that the generation change correctly happens (by adding additional node to the cluster).

Refs #33.