### PR TITLE
Route Flogger logs to log4j in Connector

### DIFF
--- a/scylla-cdc-kafka-connect/pom.xml
+++ b/scylla-cdc-kafka-connect/pom.xml
@@ -163,6 +163,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <debezium.version>1.4.1.Final</debezium.version>
         <kafka.version>2.6.0</kafka.version>
+        <flogger.version>0.5.1</flogger.version>
     </properties>
 
     <dependencies>
@@ -190,6 +191,33 @@
             <groupId>org.apache.kafka</groupId>
             <artifactId>connect-api</artifactId>
             <version>${kafka.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.flogger</groupId>
+            <artifactId>flogger-log4j-backend</artifactId>
+            <version>${flogger.version}</version>
+            <exclusions>
+                <!--
+                This is a known (not fixed) problem, that
+                flogger-log4j-backend pulls some log4j
+                transitive dependencies that have now been
+                removed from Maven due to licensing issues.
+
+                The workaround is to exclude those dependencies.
+                -->
+                <exclusion>
+                    <groupId>com.sun.jmx</groupId>
+                    <artifactId>jmxri</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>com.sun.jdmk</groupId>
+                    <artifactId>jmxtools</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>javax.jms</groupId>
+                    <artifactId>jms</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 </project>

--- a/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnector.java
+++ b/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnector.java
@@ -30,6 +30,14 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 public class ScyllaConnector extends SourceConnector {
+    static {
+        // Route Flogger logs from scylla-cdc-java library
+        // to log4j.
+        System.setProperty(
+                "flogger.backend_factory",
+                "com.google.common.flogger.backend.log4j.Log4jBackendFactory#getInstance");
+    }
+
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private Configuration config;

--- a/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorTask.java
+++ b/scylla-cdc-kafka-connect/src/main/java/com/scylladb/cdc/debezium/connector/ScyllaConnectorTask.java
@@ -31,6 +31,13 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 public class ScyllaConnectorTask extends BaseSourceTask {
+    static {
+        // Route Flogger logs from scylla-cdc-java library
+        // to log4j.
+        System.setProperty(
+                "flogger.backend_factory",
+                "com.google.common.flogger.backend.log4j.Log4jBackendFactory#getInstance");
+    }
 
     private static final String CONTEXT_NAME = "scylla-connector-task";
 


### PR DESCRIPTION
Add routing of Flogger logs in Scylla CDC Source Connector to log4j.

Flogger is used in the underlying scylla-cdc-java library and before this change those logs were not forwarded to log4j. Debezium (as well as  Kafka and Kafka Connect) use the log4j library.

To perform this routing, a dependency on flogger-log4j-backend is added. In static block `flogger.backend_factory` property is changed to use the log4j backend. This static block is placed before any other static initializations and it is present in two classes that can be loaded by Kafka Connect - `ScyllaConnector` and `ScyllaConnectorTask`. Such placement is very important, as it MUST be executed before any `FluentLogger.forEnclosingClass()` invocations (which read the System property).

I have done the following testing:
1. Run the connector on Confluent Platform. Logs from underlying library were correctly forwarded.
2. Run the connector on open-source Kafka (2.6.0), in Kafka Connect distributed mode (2 nodes). The first node loaded `ScyllaConnector` class (and afterwards the `ScyllaConnectorTask` class) and correctly forwarded the logs. The second node loaded only `ScyllaConnectorTask` class and also correctly forwarded the logs.