### PR TITLE
Worker unit tests

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/Task.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/Task.java
@@ -1,5 +1,6 @@
 package com.scylladb.cdc.model.worker;
 
+import java.util.Objects;
 import java.util.SortedSet;
 
 import com.google.common.base.Preconditions;
@@ -25,5 +26,25 @@ public final class Task {
     public Task updateState(ChangeId lastSeenChangeId) {
         Preconditions.checkNotNull(lastSeenChangeId);
         return new Task(id, streams, state.update(lastSeenChangeId));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Task)) return false;
+        Task task = (Task) o;
+        return id.equals(task.id) &&
+                streams.equals(task.streams) &&
+                state.equals(task.state);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("Task(%s, %s, %s)", id, streams, state);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, streams, state);
     }
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/TaskAction.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/TaskAction.java
@@ -79,7 +79,7 @@ abstract class TaskAction {
 
         private CompletableFuture<Void> waitForWindow() {
             Date end = task.state.getWindowEndTimestamp().toDate();
-            Date now = new Date();
+            Date now = Date.from(workerConfiguration.getClock().instant());
             long toWait = end.getTime() - now.getTime() + workerConfiguration.confidenceWindowSizeMs;
             if (toWait > 0) {
                 return delay(toWait);

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/TaskState.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/TaskState.java
@@ -28,6 +28,19 @@ public final class TaskState {
         return TimeUUID.startOf(windowStart.toDate().getTime());
     }
 
+    /**
+     * Returns the timestamp of the start of the query window.
+     * <p>
+     * This timestamp represents a inclusive lower bound
+     * of changes defined by this <code>TaskState</code>.
+     *
+     * @return the timestamp of the start of the query window.
+     * @see #getWindowEndTimestamp()
+     */
+    public Timestamp getWindowStartTimestamp() {
+        return windowStart;
+    }
+
     public boolean hasPassed(Timestamp t) {
         return windowStart.compareTo(t) > 0;
     }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/TimeUUID.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/TimeUUID.java
@@ -38,6 +38,10 @@ class TimeUUID {
         return new UUID(makeMSB(fromUnixTimestamp(timestamp + 1) - 1), MAX_CLOCK_SEQ_AND_NODE);
     }
 
+    protected static UUID middleOf(long timestamp) {
+        return new UUID(makeMSB(fromUnixTimestamp(timestamp) + 5000), 0);
+    }
+
     private static long fromUnixTimestamp(long tstamp) {
         return (tstamp - START_EPOCH) * 10000;
     }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/Worker.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/Worker.java
@@ -67,7 +67,7 @@ public final class Worker {
         TaskState initialState = getInitialStateForStreams(groupedStreams, workerConfiguration.queryTimeWindowSizeMs);
 
         Set<TableName> tableNames = groupedStreams.keySet().stream().map(TaskId::getTable).collect(Collectors.toSet());
-        Date now = new Date();
+        Date now = Date.from(workerConfiguration.getClock().instant());
 
         // The furthest point in time where there might be
         // a CDC change, given table's TTL.

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/cql/MockWorkerCQL.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/cql/MockWorkerCQL.java
@@ -1,0 +1,129 @@
+package com.scylladb.cdc.cql;
+
+import com.google.common.base.Preconditions;
+import com.scylladb.cdc.cql.error.worker.NoOpErrorInject;
+import com.scylladb.cdc.cql.error.worker.ErrorInject;
+import com.scylladb.cdc.model.TableName;
+import com.scylladb.cdc.model.worker.*;
+
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+public class MockWorkerCQL implements WorkerCQL {
+    private volatile Map<TableName, Optional<Long>> tablesTTL = new HashMap<>();
+    private volatile List<RawChange> rawChanges = Collections.emptyList();
+    private final Set<Task> createReaderInvocations = ConcurrentHashMap.newKeySet();
+    private final Set<Task> finishedReaders = ConcurrentHashMap.newKeySet();
+    private volatile ErrorInject cqlErrorStrategy = new NoOpErrorInject();
+    private final AtomicInteger failureCount = new AtomicInteger(0);
+
+    class MockReaderCQL implements WorkerCQL.Reader {
+        private final Task task;
+        private final Iterator<RawChange> rawChangeIterator;
+
+        public MockReaderCQL(Task task, Iterator<RawChange> rawChangeIterator) {
+            this.task = task;
+            this.rawChangeIterator = Preconditions.checkNotNull(rawChangeIterator);
+        }
+
+        @Override
+        public CompletableFuture<Optional<RawChange>> nextChange() {
+            if (rawChangeIterator.hasNext()) {
+                Optional<RawChange> readChange = Optional.of(rawChangeIterator.next());
+
+                // Maybe inject an error.
+                CompletableFuture<Optional<RawChange>> injectedError = cqlErrorStrategy.injectFailure(readChange);
+                if (injectedError != null) {
+                    failureCount.incrementAndGet();
+                    return injectedError;
+                }
+
+                return CompletableFuture.completedFuture(readChange);
+            } else {
+                // Maybe inject an error.
+                CompletableFuture<Optional<RawChange>> injectedError = cqlErrorStrategy.injectFailure(Optional.empty());
+                if (injectedError != null) {
+                    failureCount.incrementAndGet();
+                    return injectedError;
+                }
+
+                finishedReaders.add(task);
+                return CompletableFuture.completedFuture(Optional.empty());
+            }
+        }
+    }
+
+    @Override
+    public void prepare(Set<TableName> tables) {
+        // No-op
+    }
+
+    @Override
+    public CompletableFuture<Reader> createReader(Task task) {
+        createReaderInvocations.add(task);
+
+        long taskStartMs = task.state.getWindowStartTimestamp().toDate().getTime();
+        long taskEndMs = task.state.getWindowEndTimestamp().toDate().getTime();
+        Optional<ChangeId> lastConsumedChangeId = task.state.getLastConsumedChangeId();
+
+        List<RawChange> collectedChanges = rawChanges.stream().filter(change -> {
+            // FIXME: Also check table name.
+
+            if (task.streams.stream().noneMatch(s -> s.equals(change.getId().getStreamId()))) {
+                return false;
+            }
+
+            long changeTimestampMs = change.getId().getChangeTime().getDate().getTime();
+            if (changeTimestampMs < taskStartMs || changeTimestampMs >= taskEndMs) {
+                return false;
+            }
+
+            if (lastConsumedChangeId.isPresent()) {
+                return change.getId().compareTo(lastConsumedChangeId.get()) > 0;
+            }
+
+            return true;
+        }).collect(Collectors.toList());
+
+        return CompletableFuture.completedFuture(new MockReaderCQL(task, collectedChanges.iterator()));
+    }
+
+    @Override
+    public CompletableFuture<Optional<Long>> fetchTableTTL(TableName tableName) {
+        Optional<Long> ttl = tablesTTL.getOrDefault(tableName, Optional.empty());
+        return CompletableFuture.completedFuture(ttl);
+    }
+
+    public void setRawChanges(List<MockRawChange> rawChanges) {
+        this.rawChanges = rawChanges.stream().sorted(
+                Comparator.comparing(RawChange::getId)
+                        .thenComparingInt(RawChange::getBatchSequenceNumber)).collect(Collectors.toList());
+    }
+
+    public void setTablesTTL(Map<TableName, Optional<Long>> tablesTTL) {
+        this.tablesTTL = tablesTTL;
+    }
+
+    public boolean wasCreateReaderInvoked(Task task) {
+        return createReaderInvocations.contains(task);
+    }
+
+    public Collection<Task> getCreateReaderInvocations(ChangeId changeId) {
+        return createReaderInvocations.stream().filter(t -> t.streams.contains(changeId.getStreamId())).collect(Collectors.toSet());
+    }
+
+    public boolean isReaderFinished(Task task) {
+        return finishedReaders.contains(task);
+    }
+
+    public void setCQLErrorStrategy(ErrorInject errorStrategy) {
+        this.cqlErrorStrategy = Preconditions.checkNotNull(errorStrategy);
+    }
+
+    public int getFailureCount() {
+        return failureCount.get();
+    }
+}

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/cql/error/worker/ContinuousChangeErrorInject.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/cql/error/worker/ContinuousChangeErrorInject.java
@@ -1,0 +1,64 @@
+package com.scylladb.cdc.cql.error.worker;
+
+import com.scylladb.cdc.model.worker.RawChange;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * An <code>ErrorInject</code> strategy that allows
+ * for error injection for a specific <code>RawChange</code>
+ * until it is manually stopped.
+ * <p>
+ * The {@link #requestRawChangeError(RawChange)} method allows
+ * for specifying a moment this class will inject an error. This
+ * error will happen continuously each time the same change
+ * is seen. The {@link #cancelRequestRawChangeError(RawChange)}
+ * allows for canceling the error injection request.
+ * <p>
+ * This class is thread-safe.
+ *
+ * @see OnceChangeErrorInject
+ */
+public class ContinuousChangeErrorInject implements ErrorInject {
+    private final Set<RawChange> requestedRawChangeError = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    /**
+     * Requests an injection of error at a specific
+     * change. The error injection will
+     * happen continuously - every time the same
+     * change is seen again.
+     *
+     * @param rawChange the change that causes an injection of an error.
+     * @see OnceChangeErrorInject#requestRawChangeError(RawChange)
+     */
+    public void requestRawChangeError(RawChange rawChange) {
+        requestedRawChangeError.add(rawChange);
+    }
+
+    /**
+     * Cancels a request for injection of error
+     * at a specific change. After this method
+     * is called, no error injection will happen
+     * for the given change.
+     *
+     * @param rawChange the change to cancel a error injection request for.
+     */
+    public void cancelRequestRawChangeError(RawChange rawChange) {
+        requestedRawChangeError.remove(rawChange);
+    }
+
+    @Override
+    public CompletableFuture<Optional<RawChange>> injectFailure(Optional<RawChange> readChange) {
+        if (readChange.isPresent() && requestedRawChangeError.contains(readChange.get())) {
+            CompletableFuture<Optional<RawChange>> injectedFailure = new CompletableFuture<>();
+            injectedFailure.completeExceptionally(new RuntimeException("Injected constant specific change error in Worker."));
+            return injectedFailure;
+        }
+        return null;
+    }
+
+}

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/cql/error/worker/ErrorInject.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/cql/error/worker/ErrorInject.java
@@ -1,0 +1,29 @@
+package com.scylladb.cdc.cql.error.worker;
+
+import com.scylladb.cdc.model.worker.RawChange;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * This interface provides a pluggable way to
+ * implement different error injection strategies
+ * for <code>MockWorkerCQL</code> operations.
+ * <p>
+ * Classes implementing this interface should
+ * be thread-safe, as the test code and started
+ * <code>MockWorkerCQL</code> will operate
+ * on different threads.
+ */
+public interface ErrorInject {
+    /**
+     * Returns an exceptional future if a failure was injected or
+     * <code>null</code> if no failure was injected. This method
+     * should never return a non-exceptional completed future.
+     *
+     * @param readChange the original change without any failures.
+     * @return an exceptional future if a failure was injected or
+     *         <code>null</code> if no failure was injected.
+     */
+    CompletableFuture<Optional<RawChange>> injectFailure(Optional<RawChange> readChange);
+}

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/cql/error/worker/NoOpErrorInject.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/cql/error/worker/NoOpErrorInject.java
@@ -1,0 +1,17 @@
+package com.scylladb.cdc.cql.error.worker;
+
+import com.scylladb.cdc.model.worker.RawChange;
+
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * An <code>ErrorInject</code> implementation
+ * that never injects an error.
+ */
+public class NoOpErrorInject implements ErrorInject {
+    @Override
+    public CompletableFuture<Optional<RawChange>> injectFailure(Optional<RawChange> readChange) {
+        return null;
+    }
+}

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/cql/error/worker/OnceChangeErrorInject.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/cql/error/worker/OnceChangeErrorInject.java
@@ -1,0 +1,48 @@
+package com.scylladb.cdc.cql.error.worker;
+
+import com.scylladb.cdc.model.worker.RawChange;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * An <code>ErrorInject</code> strategy that allows
+ * for error injection for a specific <code>RawChange</code>.
+ * <p>
+ * The {@link #requestRawChangeError(RawChange)} method allows
+ * for specifying a moment this class will inject an error.
+ * <p>
+ * This class is thread-safe.
+ *
+ * @see ContinuousChangeErrorInject
+ */
+public class OnceChangeErrorInject implements ErrorInject {
+    private final Set<RawChange> requestedRawChangeError = Collections.newSetFromMap(new ConcurrentHashMap<>());
+
+    /**
+     * Requests an injection of error at a specific
+     * change. The error injection will only
+     * happen once, meaning if the same change
+     * is seen the second time, no failure will
+     * happen.
+     *
+     * @param rawChange the change that causes an injection of an error.
+     * @see ContinuousChangeErrorInject#requestRawChangeError(RawChange) 
+     */
+    public void requestRawChangeError(RawChange rawChange) {
+        requestedRawChangeError.add(rawChange);
+    }
+
+    @Override
+    public CompletableFuture<Optional<RawChange>> injectFailure(Optional<RawChange> readChange) {
+        if (readChange.isPresent() && requestedRawChangeError.remove(readChange.get())) {
+            CompletableFuture<Optional<RawChange>> injectedFailure = new CompletableFuture<>();
+            injectedFailure.completeExceptionally(new RuntimeException("Injected specific change error in Worker."));
+            return injectedFailure;
+        }
+        return null;
+    }
+}

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/master/MockGenerationMetadata.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/master/MockGenerationMetadata.java
@@ -1,33 +1,62 @@
 package com.scylladb.cdc.model.master;
 
 import com.scylladb.cdc.model.StreamId;
+import com.scylladb.cdc.model.TaskId;
+import com.scylladb.cdc.model.TableName;
+import com.scylladb.cdc.model.VNodeId;
 import com.scylladb.cdc.model.Timestamp;
 
 import java.nio.ByteBuffer;
 import java.util.*;
+import java.util.stream.Collectors;
 
 public class MockGenerationMetadata {
     public static GenerationMetadata mockGenerationMetadata(Timestamp start, Optional<Timestamp> end, int vnodeCount) {
+        return mockGenerationMetadata(start, end, vnodeCount, 4);
+    }
+
+    public static GenerationMetadata mockGenerationMetadata(Timestamp start, Optional<Timestamp> end,
+                                                            int vnodeCount, int streamsPerVnode) {
         // Random with deterministic seed
         Random random = new Random(start.toDate().getTime());
 
         SortedSet<StreamId> streams = new TreeSet<>();
         for (int vnode = 0; vnode < vnodeCount; vnode++) {
-            long upperDword = random.nextLong(); // <token:64>
-            long lowerDword = random.nextLong(); // <random:38>
-            lowerDword = lowerDword << 22;
-            lowerDword |= vnode; // <index:22>
-            lowerDword = lowerDword << 4;
-            lowerDword |= 1; // <version:4>
+            for (int stream = 0; stream < streamsPerVnode; stream++) {
+                long upperDword = random.nextLong(); // <token:64>
+                long lowerDword = random.nextLong(); // <random:38>
+                lowerDword = lowerDword << 22;
+                lowerDword |= vnode; // <index:22>
+                lowerDword = lowerDword << 4;
+                lowerDword |= 1; // <version:4>
 
-            ByteBuffer buffer = ByteBuffer.allocate(16);
-            buffer.putLong(upperDword);
-            buffer.putLong(lowerDword);
-            buffer.position(0);
+                ByteBuffer buffer = ByteBuffer.allocate(16);
+                buffer.putLong(upperDword);
+                buffer.putLong(lowerDword);
+                buffer.position(0);
 
-            StreamId streamId = new StreamId(buffer);
-            streams.add(streamId);
+                StreamId streamId = new StreamId(buffer);
+                streams.add(streamId);
+            }
         }
         return new GenerationMetadata(start, end, streams);
+    }
+
+    public static Map<TaskId, SortedSet<StreamId>> generationMetadataToTaskMap(
+            GenerationMetadata generationMetadata, Set<TableName> tableNames) {
+        Map<TaskId, SortedSet<StreamId>> generationMetadataMap = new HashMap<>();
+        List<VNodeId> vNodes = generationMetadata.getStreams().stream()
+                .map(StreamId::getVNodeId).distinct().collect(Collectors.toList());
+
+        // FIXME - quadratic complexity (|vNodes|^2)
+        for (TableName tableName : tableNames) {
+            for (VNodeId vNodeId : vNodes) {
+                TaskId taskId = new TaskId(generationMetadata.getId(), vNodeId, tableName);
+                SortedSet<StreamId> streamIds = generationMetadata.getStreams().stream()
+                        .filter(s -> s.getVNodeId().equals(vNodeId)).collect(Collectors.toCollection(TreeSet::new));
+                generationMetadataMap.put(taskId, streamIds);
+            }
+        }
+        return generationMetadataMap;
     }
 }

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/WorkerTest.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/WorkerTest.java
@@ -1,0 +1,659 @@
+package com.scylladb.cdc.model.worker;
+
+import com.google.common.collect.Lists;
+import com.scylladb.cdc.cql.MockWorkerCQL;
+import com.scylladb.cdc.cql.error.worker.ContinuousChangeErrorInject;
+import com.scylladb.cdc.cql.error.worker.OnceChangeErrorInject;
+import com.scylladb.cdc.model.*;
+import com.scylladb.cdc.model.master.GenerationMetadata;
+import com.scylladb.cdc.model.master.MockGenerationMetadata;
+import com.scylladb.cdc.transport.MockWorkerTransport;
+import org.awaitility.core.ConditionFactory;
+import org.junit.jupiter.api.Test;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.*;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+import static com.scylladb.cdc.model.worker.WorkerThread.DEFAULT_QUERY_WINDOW_SIZE_MS;
+import static org.awaitility.Awaitility.with;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+public class WorkerTest {
+    private static final long DEFAULT_AWAIT_TIMEOUT_MS = 2000;
+    private static final ConditionFactory DEFAULT_AWAIT =
+            with().pollInterval(1, TimeUnit.MILLISECONDS).await()
+                    .atMost(DEFAULT_AWAIT_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+
+    private static long TEST_GENERATION_START_MS = 5 * 60 * 1000;
+    private static int TEST_GENERATION_VNODE_COUNT = 16;
+    private static int TEST_GENERATION_STREAMS_PER_VNODE_COUNT = 4;
+    private static GenerationMetadata TEST_GENERATION = MockGenerationMetadata.mockGenerationMetadata(
+            new Timestamp(new Date(TEST_GENERATION_START_MS)), Optional.empty(),
+            TEST_GENERATION_VNODE_COUNT, TEST_GENERATION_STREAMS_PER_VNODE_COUNT);
+
+    protected static TableName TEST_TABLE_NAME = new TableName("ks", "t");
+
+    // ChangeSchema for table:
+    // CREATE TABLE ks.t(pk int, ck int, v int, PRIMARY KEY(pk, ck)) WITH cdc = {'enabled': true};
+    protected static ChangeSchema TEST_CHANGE_SCHEMA = new ChangeSchema(Lists.newArrayList(
+            new ChangeSchema.ColumnDefinition("cdc$stream_id", 0, new ChangeSchema.DataType(ChangeSchema.CqlType.BLOB), null, null),
+            new ChangeSchema.ColumnDefinition("cdc$time", 1, new ChangeSchema.DataType(ChangeSchema.CqlType.TIMEUUID), null, null),
+            new ChangeSchema.ColumnDefinition("cdc$batch_seq_no", 2, new ChangeSchema.DataType(ChangeSchema.CqlType.INT), null, null),
+            new ChangeSchema.ColumnDefinition("cdc$deleted_v", 3, new ChangeSchema.DataType(ChangeSchema.CqlType.BOOLEAN), null, null),
+            new ChangeSchema.ColumnDefinition("cdc$end_of_batch", 4, new ChangeSchema.DataType(ChangeSchema.CqlType.BOOLEAN), null, null),
+            new ChangeSchema.ColumnDefinition("cdc$operation", 5, new ChangeSchema.DataType(ChangeSchema.CqlType.TINYINT), null, null),
+            new ChangeSchema.ColumnDefinition("cdc$ttl", 6, new ChangeSchema.DataType(ChangeSchema.CqlType.BIGINT), null, null),
+            new ChangeSchema.ColumnDefinition("ck", 7, new ChangeSchema.DataType(ChangeSchema.CqlType.INT), new ChangeSchema.DataType(ChangeSchema.CqlType.INT), ChangeSchema.ColumnType.CLUSTERING_KEY),
+            new ChangeSchema.ColumnDefinition("pk", 8, new ChangeSchema.DataType(ChangeSchema.CqlType.INT), new ChangeSchema.DataType(ChangeSchema.CqlType.INT), ChangeSchema.ColumnType.PARTITION_KEY),
+            new ChangeSchema.ColumnDefinition("v", 9, new ChangeSchema.DataType(ChangeSchema.CqlType.INT), new ChangeSchema.DataType(ChangeSchema.CqlType.INT), ChangeSchema.ColumnType.REGULAR)
+    ));
+
+    @Test
+    public void testWorkerReadsAnyWindows() {
+        // Worker should start reading windows
+        // from the beginning of the generation.
+
+        MockWorkerTransport workerTransport = new MockWorkerTransport();
+        MockWorkerCQL mockWorkerCQL = new MockWorkerCQL();
+        Consumer noOpConsumer = Consumer.syncRawChangeConsumer(c -> {});
+
+        try (WorkerThread workerThread = new WorkerThread(
+                mockWorkerCQL, workerTransport, noOpConsumer, TEST_GENERATION, TEST_TABLE_NAME)) {
+            DEFAULT_AWAIT.until(() -> mockWorkerCQL.isReaderFinished(generateTask(TEST_GENERATION, 0, TEST_TABLE_NAME,
+                    TEST_GENERATION_START_MS, TEST_GENERATION_START_MS + DEFAULT_QUERY_WINDOW_SIZE_MS)));
+
+            DEFAULT_AWAIT.until(() -> mockWorkerCQL.isReaderFinished(generateTask(TEST_GENERATION, 0, TEST_TABLE_NAME,
+                    TEST_GENERATION_START_MS + DEFAULT_QUERY_WINDOW_SIZE_MS,
+                    TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS)));
+
+            DEFAULT_AWAIT.until(() -> mockWorkerCQL.isReaderFinished(generateTask(TEST_GENERATION, 0, TEST_TABLE_NAME,
+                    TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS,
+                    TEST_GENERATION_START_MS + 3 * DEFAULT_QUERY_WINDOW_SIZE_MS)));
+
+            DEFAULT_AWAIT.until(() -> mockWorkerCQL.isReaderFinished(generateTask(TEST_GENERATION, 3, TEST_TABLE_NAME,
+                    TEST_GENERATION_START_MS, TEST_GENERATION_START_MS + DEFAULT_QUERY_WINDOW_SIZE_MS)));
+        }
+    }
+
+    @Test
+    public void testWorkerTrimsWindowWithTTL() {
+        // If a TTL was set on a table (as is the case
+        // in Scylla by default on the CDC log table), Worker
+        // should not start reading from the beginning of
+        // generation, but from |now - ttl|.
+
+        MockWorkerTransport workerTransport = new MockWorkerTransport();
+        MockWorkerCQL mockWorkerCQL = new MockWorkerCQL();
+
+        // "Now" will be at second 935 and 146 second TTL:
+        long now = 935, ttl = 146;
+        mockWorkerCQL.setTablesTTL(Collections.singletonMap(TEST_TABLE_NAME, Optional.of(ttl)));
+        Clock clock = Clock.fixed(Instant.ofEpochSecond(now), ZoneOffset.systemDefault());
+
+        Consumer noOpConsumer = Consumer.syncRawChangeConsumer(c -> {});
+
+        try (WorkerThread workerThread = new WorkerThread(
+                mockWorkerCQL, workerTransport, noOpConsumer, TEST_GENERATION, clock, TEST_TABLE_NAME)) {
+
+            // Expecting to see a window queried from time point (now - ttl).
+            // Multiplying by 1000 to convert from seconds to milliseconds.
+            DEFAULT_AWAIT.until(() -> mockWorkerCQL.isReaderFinished(generateTask(TEST_GENERATION, 0, TEST_TABLE_NAME,
+                    (now - ttl) * 1000, (now - ttl) * 1000 + DEFAULT_QUERY_WINDOW_SIZE_MS)));
+
+            // And no window before that:
+            assertFalse(mockWorkerCQL.wasCreateReaderInvoked(generateTask(TEST_GENERATION, 0, TEST_TABLE_NAME,
+                    (now - ttl) * 1000 - DEFAULT_QUERY_WINDOW_SIZE_MS, (now - ttl) * 1000)));
+        }
+    }
+
+    @Test
+    public void testWorkerTrimsSavedTaskStatesWithTTL() {
+        // If a TTL is set on a table, but
+        // there are TaskStates saved on the transport,
+        // they still should be trimmed with the TTL value.
+
+        // "Now" will be at second 935 and 146 second TTL:
+        long now = 935, ttl = 146;
+        Clock clock = Clock.fixed(Instant.ofEpochSecond(now), ZoneOffset.systemDefault());
+
+        MockWorkerTransport workerTransport = new MockWorkerTransport();
+        // Previously saved TaskStates:
+        // task1 - before TTL
+        // task2 - after TTL
+        // task3 - intersecting with TTL
+        Task task1 = generateTask(TEST_GENERATION, 0, TEST_TABLE_NAME,
+                TEST_GENERATION_START_MS + 18 * DEFAULT_QUERY_WINDOW_SIZE_MS,
+                TEST_GENERATION_START_MS + 19 * DEFAULT_QUERY_WINDOW_SIZE_MS);
+        Task task2 = generateTask(TEST_GENERATION, 1, TEST_TABLE_NAME,
+                900 * 1000, 900 * 1000 + DEFAULT_QUERY_WINDOW_SIZE_MS);
+        Task task3 = generateTask(TEST_GENERATION, 2, TEST_TABLE_NAME,
+                (now - ttl) * 1000 - 3,
+                (now - ttl) * 1000 - 3 + DEFAULT_QUERY_WINDOW_SIZE_MS);
+        // FIXME: add a test with TaskState with lastConsumedId
+
+        workerTransport.setState(task1.id, task1.state);
+        workerTransport.setState(task2.id, task2.state);
+        workerTransport.setState(task3.id, task3.state);
+
+        MockWorkerCQL mockWorkerCQL = new MockWorkerCQL();
+        mockWorkerCQL.setTablesTTL(Collections.singletonMap(TEST_TABLE_NAME, Optional.of(ttl)));
+
+        Consumer noOpConsumer = Consumer.syncRawChangeConsumer(c -> {});
+
+        try (WorkerThread workerThread = new WorkerThread(
+                mockWorkerCQL, workerTransport, noOpConsumer, TEST_GENERATION, clock, TEST_TABLE_NAME)) {
+            // task1 - before TTL, so Worker should start reading
+            // from TTL, "discarding" task1.
+            DEFAULT_AWAIT.until(() -> mockWorkerCQL.isReaderFinished(generateTask(TEST_GENERATION, 0, TEST_TABLE_NAME,
+                    (now - ttl) * 1000, (now - ttl) * 1000 + DEFAULT_QUERY_WINDOW_SIZE_MS)));
+            assertFalse(mockWorkerCQL.wasCreateReaderInvoked(generateTask(TEST_GENERATION, 0, TEST_TABLE_NAME,
+                    (now - ttl) * 1000 - DEFAULT_QUERY_WINDOW_SIZE_MS, (now - ttl) * 1000)));
+
+            // task2 - after TTL, so Worker should start reading
+            // from it.
+            DEFAULT_AWAIT.until(() -> mockWorkerCQL.isReaderFinished(task2));
+            assertFalse(mockWorkerCQL.wasCreateReaderInvoked(task2.updateState(task2.state.moveToNextWindow(-DEFAULT_QUERY_WINDOW_SIZE_MS))));
+
+            // task3 - intersecting with TTL. For simplicity,
+            // the Worker does not trim it and starts from it.
+            DEFAULT_AWAIT.until(() -> mockWorkerCQL.isReaderFinished(task3));
+            assertFalse(mockWorkerCQL.wasCreateReaderInvoked(task3.updateState(task3.state.moveToNextWindow(-DEFAULT_QUERY_WINDOW_SIZE_MS))));
+        }
+    }
+
+    @Test
+    public void testWorkerConsumesSingleVNodeChangesInOrder() {
+        // Worker should consume changes within a single
+        // vnode in order of stream id and timestamp.
+
+        MockRawChange change1 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 0)
+                .withTimeMs(TEST_GENERATION_START_MS + 12)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 2)
+                .addAtomicRegularColumn("v", 3)
+                .build();
+
+        MockRawChange change2 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 1)
+                .withTimeMs(TEST_GENERATION_START_MS + 12)
+                .addPrimaryKey("pk", 4)
+                .addPrimaryKey("ck", 5)
+                .addAtomicRegularColumn("v", 6)
+                .build();
+
+        MockRawChange change3 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 2)
+                .withTimeMs(TEST_GENERATION_START_MS + 13)
+                .addPrimaryKey("pk", 7)
+                .addPrimaryKey("ck", 8)
+                .addAtomicRegularColumn("v", 9)
+                .build();
+
+        MockRawChange change4 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 0)
+                .withTimeMs(TEST_GENERATION_START_MS + 19)
+                .addPrimaryKey("pk", 10)
+                .addPrimaryKey("ck", 11)
+                .addAtomicRegularColumn("v", 12)
+                .build();
+
+        MockRawChange change5 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 3)
+                .withTimeMs(TEST_GENERATION_START_MS + 100)
+                .addPrimaryKey("pk", 13)
+                .addPrimaryKey("ck", 14)
+                .addAtomicRegularColumn("v", 15)
+                .build();
+
+        MockWorkerTransport workerTransport = new MockWorkerTransport();
+        MockWorkerCQL mockWorkerCQL = new MockWorkerCQL();
+        List<MockRawChange> rawChanges = Lists.newArrayList(change1, change2, change3, change4, change5);
+        mockWorkerCQL.setRawChanges(rawChanges);
+        List<RawChange> observedChanges = Collections.synchronizedList(new ArrayList<>());
+        Consumer accumulatingConsumer = Consumer.syncRawChangeConsumer(observedChanges::add);
+
+        try (WorkerThread workerThread = new WorkerThread(
+                mockWorkerCQL, workerTransport, accumulatingConsumer, TEST_GENERATION, TEST_TABLE_NAME)) {
+            DEFAULT_AWAIT.until(() -> observedChanges.equals(rawChanges));
+        }
+    }
+
+    @Test
+    public void testWorkerConsumesMultiVNodeChanges() {
+        // Worker should be able to read changes
+        // from all vnodes, many windows.
+
+        List<MockRawChange> rawChanges = new ArrayList<>();
+        for (int vnode = 0; vnode < 16; vnode++) {
+            rawChanges.add(MockRawChange.builder()
+                    .withChangeSchema(TEST_CHANGE_SCHEMA)
+                    .withStreamId(TEST_GENERATION, vnode, 2)
+                    .withTimeMs(TEST_GENERATION_START_MS + 17)
+                    .addPrimaryKey("pk", 15)
+                    .addPrimaryKey("ck", 1)
+                    .addAtomicRegularColumn("v", 7)
+                    .build());
+
+            rawChanges.add(MockRawChange.builder()
+                    .withChangeSchema(TEST_CHANGE_SCHEMA)
+                    .withStreamId(TEST_GENERATION, vnode, 1)
+                    .withTimeMs(TEST_GENERATION_START_MS + 17)
+                    .addPrimaryKey("pk", 11)
+                    .addPrimaryKey("ck", vnode)
+                    .addAtomicRegularColumn("v", 3)
+                    .build());
+
+            rawChanges.add(MockRawChange.builder()
+                    .withChangeSchema(TEST_CHANGE_SCHEMA)
+                    .withStreamId(TEST_GENERATION, vnode, 1)
+                    .withTimeMs(TEST_GENERATION_START_MS + 44)
+                    .addPrimaryKey("pk", vnode)
+                    .addPrimaryKey("ck", 2)
+                    .addAtomicRegularColumn("v", 3)
+                    .build());
+
+            rawChanges.add(MockRawChange.builder()
+                    .withChangeSchema(TEST_CHANGE_SCHEMA)
+                    .withStreamId(TEST_GENERATION, vnode, 3)
+                    .withTimeMs(TEST_GENERATION_START_MS + 48 + vnode * 3)
+                    .addPrimaryKey("pk", 12)
+                    .addPrimaryKey("ck", 5)
+                    .addAtomicRegularColumn("v", vnode)
+                    .build());
+        }
+
+        MockWorkerTransport workerTransport = new MockWorkerTransport();
+        MockWorkerCQL mockWorkerCQL = new MockWorkerCQL();
+        mockWorkerCQL.setRawChanges(rawChanges);
+        List<RawChange> observedChanges = Collections.synchronizedList(new ArrayList<>());
+        Consumer accumulatingConsumer = Consumer.syncRawChangeConsumer(observedChanges::add);
+
+        try (WorkerThread workerThread = new WorkerThread(
+                mockWorkerCQL, workerTransport, accumulatingConsumer, TEST_GENERATION, TEST_TABLE_NAME)) {
+            DEFAULT_AWAIT.until(() -> observedChanges.containsAll(rawChanges));
+            // No duplicates:
+            assertEquals(observedChanges.size(), rawChanges.size());
+        }
+    }
+
+    @Test
+    public void testWorkerConsumesChangesFromSavedTaskState() {
+        // Worker should start reading changes
+        // from the TaskState in Transport,
+        // and skip changes before that state.
+
+        MockRawChange change1 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 0)
+                .withTimeMs(TEST_GENERATION_START_MS + 12)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 2)
+                .addAtomicRegularColumn("v", 3)
+                .build();
+
+        MockRawChange change2 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 1)
+                .withTimeMs(TEST_GENERATION_START_MS + 12)
+                .addPrimaryKey("pk", 4)
+                .addPrimaryKey("ck", 5)
+                .addAtomicRegularColumn("v", 6)
+                .build();
+
+        MockRawChange change3 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 2)
+                .withTimeMs(TEST_GENERATION_START_MS + 13)
+                .addPrimaryKey("pk", 7)
+                .addPrimaryKey("ck", 8)
+                .addAtomicRegularColumn("v", 9)
+                .build();
+
+        MockRawChange change4 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 0)
+                .withTimeMs(TEST_GENERATION_START_MS + 19)
+                .addPrimaryKey("pk", 10)
+                .addPrimaryKey("ck", 11)
+                .addAtomicRegularColumn("v", 12)
+                .build();
+
+        MockRawChange change5 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 3)
+                .withTimeMs(TEST_GENERATION_START_MS + 100)
+                .addPrimaryKey("pk", 13)
+                .addPrimaryKey("ck", 14)
+                .addAtomicRegularColumn("v", 15)
+                .build();
+
+        MockWorkerTransport workerTransport = new MockWorkerTransport();
+        Task savedTask = generateTask(TEST_GENERATION, 0, TEST_TABLE_NAME,
+                TEST_GENERATION_START_MS + 3 * DEFAULT_QUERY_WINDOW_SIZE_MS,
+                TEST_GENERATION_START_MS + 4 * DEFAULT_QUERY_WINDOW_SIZE_MS);
+        workerTransport.setState(savedTask.id, savedTask.state);
+
+        MockWorkerCQL mockWorkerCQL = new MockWorkerCQL();
+        List<MockRawChange> rawChanges = Lists.newArrayList(change1, change2, change3, change4, change5);
+        mockWorkerCQL.setRawChanges(rawChanges);
+        List<RawChange> observedChanges = Collections.synchronizedList(new ArrayList<>());
+        Consumer accumulatingConsumer = Consumer.syncRawChangeConsumer(observedChanges::add);
+
+        try (WorkerThread workerThread = new WorkerThread(
+                mockWorkerCQL, workerTransport, accumulatingConsumer, TEST_GENERATION, TEST_TABLE_NAME)) {
+            DEFAULT_AWAIT.until(() -> observedChanges.equals(rawChanges.subList(3, 4)));
+        }
+
+        // Test with another savedTask:
+        savedTask = generateTask(TEST_GENERATION, 0, TEST_TABLE_NAME,
+                TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS,
+                TEST_GENERATION_START_MS + 3 * DEFAULT_QUERY_WINDOW_SIZE_MS);
+        savedTask = savedTask.updateState(savedTask.state.update(change1.getId()));
+        workerTransport.setState(savedTask.id, savedTask.state);
+        observedChanges.clear();
+
+        try (WorkerThread workerThread = new WorkerThread(
+                mockWorkerCQL, workerTransport, accumulatingConsumer, TEST_GENERATION, TEST_TABLE_NAME)) {
+            DEFAULT_AWAIT.until(() -> observedChanges.equals(rawChanges.subList(1, 4)));
+        }
+    }
+
+    @Test
+    public void testWorkerSavesMovedWindowStateToTransport() {
+        // Worker should call save state after each
+        // moving of window.
+
+        MockWorkerTransport workerTransport = new MockWorkerTransport();
+        MockWorkerCQL mockWorkerCQL = new MockWorkerCQL();
+        Consumer noOpConsumer = Consumer.syncRawChangeConsumer(c -> {});
+
+        // The first window is not saved using moveStateToNextWindow.
+        Task secondWindow = generateTask(TEST_GENERATION, 0, TEST_TABLE_NAME,
+                TEST_GENERATION_START_MS + DEFAULT_QUERY_WINDOW_SIZE_MS, TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS);
+        Task thirdWindow = generateTask(TEST_GENERATION, 0, TEST_TABLE_NAME,
+                TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS, TEST_GENERATION_START_MS + 3 * DEFAULT_QUERY_WINDOW_SIZE_MS);
+
+        try (WorkerThread workerThread = new WorkerThread(
+                mockWorkerCQL, workerTransport, noOpConsumer, TEST_GENERATION, TEST_TABLE_NAME)) {
+            // Wait for the third window to be committed to transport.
+            DEFAULT_AWAIT.until(() -> workerTransport.getMoveStateToNextWindowInvocations(thirdWindow.id).size() >= 2);
+        }
+
+        // Worker has now stopped, check if the transport
+        // received moveStateToNextWindow for the second
+        // and third window.
+
+        List<TaskState> windows = workerTransport.getMoveStateToNextWindowInvocations(secondWindow.id).subList(0, 2);
+        assertEquals(Lists.newArrayList(secondWindow.state, thirdWindow.state), windows);
+    }
+
+    @Test
+    public void testWorkerSavesWithinWindowStateToTransport() {
+        // Worker should call save state after
+        // each successful reading of a change.
+
+        MockRawChange change1 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 0)
+                .withTimeMs(TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS + 1)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 2)
+                .addAtomicRegularColumn("v", 3)
+                .build();
+
+        MockRawChange change2 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 0)
+                .withTimeMs(TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS + 2)
+                .addPrimaryKey("pk", 4)
+                .addPrimaryKey("ck", 5)
+                .addAtomicRegularColumn("v", 6)
+                .build();
+
+        MockWorkerTransport workerTransport = new MockWorkerTransport();
+        MockWorkerCQL mockWorkerCQL = new MockWorkerCQL();
+        List<MockRawChange> rawChanges = Lists.newArrayList(change1, change2);
+        mockWorkerCQL.setRawChanges(rawChanges);
+        List<RawChange> observedChanges = Collections.synchronizedList(new ArrayList<>());
+        Consumer accumulatingConsumer = Consumer.syncRawChangeConsumer(observedChanges::add);
+
+        try (WorkerThread workerThread = new WorkerThread(
+                mockWorkerCQL, workerTransport, accumulatingConsumer, TEST_GENERATION, TEST_TABLE_NAME)) {
+            DEFAULT_AWAIT.until(() -> observedChanges.equals(rawChanges));
+        }
+
+        // The consumer has received all changes,
+        // let's check whether it updated the windows correctly.
+        Task windowReadTask = generateTask(TEST_GENERATION, 0, TEST_TABLE_NAME,
+                TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS,
+                TEST_GENERATION_START_MS + 3 * DEFAULT_QUERY_WINDOW_SIZE_MS);
+
+        // Skip a few windows unrelated to windowReadTask:
+        List<TaskState> windows = workerTransport.getSetStateInvocations(windowReadTask.id).subList(2, 5);
+
+        TaskState windowBeginningState = windowReadTask.state;
+        TaskState afterChange1State = windowReadTask.state.update(change1.getId());
+        TaskState afterChange2State = windowReadTask.state.update(change2.getId());
+
+        assertEquals(Lists.newArrayList(windowBeginningState, afterChange1State, afterChange2State), windows);
+    }
+
+    @Test
+    public void testWorkerRetriesFailedConsumer() {
+        // Test that Worker retries after
+        // exception from Consumer and
+        // doesn't re-read changes.
+
+        MockRawChange change1 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 0)
+                .withTimeMs(TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS + 1)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 2)
+                .addAtomicRegularColumn("v", 3)
+                .build();
+
+        MockRawChange change2 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 0)
+                .withTimeMs(TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS + 2)
+                .addPrimaryKey("pk", 4)
+                .addPrimaryKey("ck", 5)
+                .addAtomicRegularColumn("v", 6)
+                .build();
+
+        MockWorkerTransport workerTransport = new MockWorkerTransport();
+        MockWorkerCQL mockWorkerCQL = new MockWorkerCQL();
+        List<MockRawChange> rawChanges = Lists.newArrayList(change1, change2);
+        mockWorkerCQL.setRawChanges(rawChanges);
+
+        // Set up a consumer that starts
+        // failing after the first change
+        // until failure mode is stopped.
+        AtomicBoolean shouldFail = new AtomicBoolean(false);
+        AtomicInteger failCount = new AtomicInteger(0);
+        List<RawChange> observedChanges = Collections.synchronizedList(new ArrayList<>());
+        Consumer failingConsumer = Consumer.forRawChangeConsumer(change -> {
+            if (shouldFail.get()) {
+                failCount.incrementAndGet();
+                CompletableFuture<Void> injectedExceptionFuture = new CompletableFuture<>();
+                injectedExceptionFuture.completeExceptionally(new RuntimeException("Injected exception in failingConsumer"));
+                return injectedExceptionFuture;
+            }
+            if (change.equals(change1)) {
+                // Start failing after the first change
+                shouldFail.set(true);
+            }
+            observedChanges.add(change);
+            return CompletableFuture.completedFuture(null);
+        });
+
+        try (WorkerThread workerThread = new WorkerThread(
+                mockWorkerCQL, workerTransport, failingConsumer, TEST_GENERATION, TEST_TABLE_NAME)) {
+            DEFAULT_AWAIT.until(() -> failCount.get() > 3);
+
+            // We should have only succeeded in reading the first change.
+            assertEquals(Collections.singletonList(change1), observedChanges);
+
+            shouldFail.set(false);
+
+            DEFAULT_AWAIT.until(() -> rawChanges.equals(observedChanges));
+        }
+    }
+
+    @Test
+    public void testWorkerRetriesSingleCQLException() {
+        // Test that Worker correctly handles
+        // a single WorkerCQL nextChange() exception.
+
+        MockRawChange change1 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 0)
+                .withTimeMs(TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS + 1)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 2)
+                .addAtomicRegularColumn("v", 3)
+                .build();
+
+        MockRawChange change2 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 0)
+                .withTimeMs(TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS + 2)
+                .addPrimaryKey("pk", 4)
+                .addPrimaryKey("ck", 5)
+                .addAtomicRegularColumn("v", 6)
+                .build();
+
+        MockWorkerTransport workerTransport = new MockWorkerTransport();
+        MockWorkerCQL mockWorkerCQL = new MockWorkerCQL();
+        List<MockRawChange> rawChanges = Lists.newArrayList(change1, change2);
+        mockWorkerCQL.setRawChanges(rawChanges);
+        List<RawChange> observedChanges = Collections.synchronizedList(new ArrayList<>());
+        Consumer accumulatingConsumer = Consumer.syncRawChangeConsumer(observedChanges::add);
+
+        // Inject a single failure.
+        OnceChangeErrorInject errorInjection = new OnceChangeErrorInject();
+        errorInjection.requestRawChangeError(change1);
+        mockWorkerCQL.setCQLErrorStrategy(errorInjection);
+
+        try (WorkerThread workerThread = new WorkerThread(
+                mockWorkerCQL, workerTransport, accumulatingConsumer, TEST_GENERATION, TEST_TABLE_NAME)) {
+            DEFAULT_AWAIT.until(() -> mockWorkerCQL.getFailureCount() == 1);
+            DEFAULT_AWAIT.until(() -> observedChanges.equals(rawChanges));
+        }
+    }
+
+    @Test
+    public void testWorkerSurvivesFailureAndRestart() {
+        // Test that Worker correctly handles the following
+        // scenario: successful reading of a few changes,
+        // then constant CQL failure, restart and successful
+        // reading of next changes.
+
+        MockRawChange change1 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 0)
+                .withTimeMs(TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS + 1)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 2)
+                .addAtomicRegularColumn("v", 3)
+                .build();
+
+        MockRawChange change2 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 0)
+                .withTimeMs(TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS + 2)
+                .addPrimaryKey("pk", 4)
+                .addPrimaryKey("ck", 5)
+                .addAtomicRegularColumn("v", 6)
+                .build();
+
+        MockRawChange change3 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 0)
+                .withTimeMs(TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS + 3)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 9)
+                .addAtomicRegularColumn("v", 4)
+                .build();
+
+        MockRawChange change4 = MockRawChange.builder()
+                .withChangeSchema(TEST_CHANGE_SCHEMA)
+                .withStreamId(TEST_GENERATION, 0, 0)
+                .withTimeMs(TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS + 4)
+                .addPrimaryKey("pk", 2)
+                .addPrimaryKey("ck", 9)
+                .addAtomicRegularColumn("v", 11)
+                .build();
+
+        MockWorkerTransport workerTransport = new MockWorkerTransport();
+        MockWorkerCQL mockWorkerCQL = new MockWorkerCQL();
+        List<MockRawChange> rawChanges = Lists.newArrayList(change1, change2, change3, change4);
+        mockWorkerCQL.setRawChanges(rawChanges);
+        List<RawChange> observedChanges = Collections.synchronizedList(new ArrayList<>());
+        Consumer accumulatingConsumer = Consumer.syncRawChangeConsumer(observedChanges::add);
+
+        // Inject a "constant" failure at change 3.
+        ContinuousChangeErrorInject errorStrategy = new ContinuousChangeErrorInject();
+        errorStrategy.requestRawChangeError(change3);
+        mockWorkerCQL.setCQLErrorStrategy(errorStrategy);
+
+        try (WorkerThread workerThread = new WorkerThread(
+                mockWorkerCQL, workerTransport, accumulatingConsumer, TEST_GENERATION, TEST_TABLE_NAME)) {
+            // Wait for a CQL failure.
+            DEFAULT_AWAIT.until(() -> mockWorkerCQL.getFailureCount() > 2);
+
+            // We will only successfully have read the first two changes.
+            DEFAULT_AWAIT.until(() -> observedChanges.equals(Lists.newArrayList(change1, change2)));
+        }
+
+        // Check if the transport has the correct TaskState.
+        Task failedTask = generateTask(TEST_GENERATION, 0, TEST_TABLE_NAME,
+                TEST_GENERATION_START_MS + 2 * DEFAULT_QUERY_WINDOW_SIZE_MS,
+                TEST_GENERATION_START_MS + 3 * DEFAULT_QUERY_WINDOW_SIZE_MS);
+        TaskState fetchedTaskState = workerTransport.getTaskStates(Collections.singleton(failedTask.id)).get(failedTask.id);
+        assertEquals(fetchedTaskState, failedTask.state.update(change2.getId()));
+
+        // Restart Worker.
+        try (WorkerThread workerThread = new WorkerThread(
+                mockWorkerCQL, workerTransport, accumulatingConsumer, TEST_GENERATION, TEST_TABLE_NAME)) {
+            // Let it fail a few times more.
+
+            int initialFailureCount = mockWorkerCQL.getFailureCount();
+            DEFAULT_AWAIT.until(() -> mockWorkerCQL.getFailureCount() > initialFailureCount + 2);
+
+            // Cancel the failure, making it possible to read all changes.
+            errorStrategy.cancelRequestRawChangeError(change3);
+
+            DEFAULT_AWAIT.until(() -> observedChanges.equals(rawChanges));
+        }
+    }
+
+    private Task generateTask(GenerationMetadata generationMetadata, int vnodeIndex, TableName tableName,
+                              long windowStartMs, long windowEndMs) {
+        VNodeId vnodeId = new VNodeId(vnodeIndex);
+        TaskId taskId = new TaskId(generationMetadata.getId(), vnodeId, tableName);
+
+        SortedSet<StreamId> streamIds = generationMetadata.getStreams().stream()
+                .filter(s -> s.getVNodeId().equals(vnodeId))
+                .collect(Collectors.toCollection(TreeSet::new));
+
+        TaskState taskState = new TaskState(new Timestamp(new Date(windowStartMs)),
+                new Timestamp(new Date(windowEndMs)), Optional.empty());
+        return new Task(taskId, streamIds, taskState);
+    }
+}

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/WorkerThread.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/WorkerThread.java
@@ -1,0 +1,85 @@
+package com.scylladb.cdc.model.worker;
+
+import com.google.common.base.Preconditions;
+import com.scylladb.cdc.cql.WorkerCQL;
+import com.scylladb.cdc.model.StreamId;
+import com.scylladb.cdc.model.TableName;
+import com.scylladb.cdc.model.TaskId;
+import com.scylladb.cdc.model.master.GenerationMetadata;
+import com.scylladb.cdc.model.master.MockGenerationMetadata;
+import com.scylladb.cdc.transport.WorkerTransport;
+
+import java.time.Clock;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.concurrent.*;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+public class WorkerThread implements AutoCloseable {
+    public static final long DEFAULT_QUERY_WINDOW_SIZE_MS = 5;
+    public static final long DEFAULT_CONFIDENCE_WINDOW_SIZE_MS = 10;
+
+    private static final long FUTURE_GET_TIMEOUT = 3000;
+    private final Worker worker;
+    private final Future<Throwable> workerRunFuture;
+
+    public WorkerThread(WorkerConfiguration workerConfiguration, Map<TaskId, SortedSet<StreamId>> groupedStreams) {
+        Preconditions.checkNotNull(workerConfiguration);
+        this.worker = new Worker(workerConfiguration);
+        this.workerRunFuture = Executors.newSingleThreadExecutor().submit(() -> {
+            try {
+                worker.run(groupedStreams);
+                return null;
+            } catch (Throwable t) {
+                return t;
+            }
+        });
+    }
+
+    public WorkerThread(WorkerCQL workerCQL, WorkerTransport workerTransport, Consumer consumer, Clock clock,
+                        Map<TaskId, SortedSet<StreamId>> groupedStreams) {
+        this(WorkerConfiguration.builder()
+                .withCQL(workerCQL)
+                .withTransport(workerTransport)
+                .withConsumer(consumer)
+                .withQueryTimeWindowSizeMs(DEFAULT_QUERY_WINDOW_SIZE_MS)
+                .withConfidenceWindowSizeMs(DEFAULT_CONFIDENCE_WINDOW_SIZE_MS)
+                .withClock(clock)
+                .build(), groupedStreams);
+    }
+
+    public WorkerThread(WorkerCQL workerCQL, WorkerTransport workerTransport, Consumer consumer,
+                        GenerationMetadata generationMetadata, Clock clock, Set<TableName> tableNames) {
+        this(workerCQL, workerTransport, consumer, clock, MockGenerationMetadata.generationMetadataToTaskMap(generationMetadata, tableNames));
+    }
+
+    public WorkerThread(WorkerCQL workerCQL, WorkerTransport workerTransport, Consumer consumer,
+                        GenerationMetadata generationMetadata, TableName tableName) {
+        this(workerCQL, workerTransport, consumer, generationMetadata, Clock.systemDefaultZone(), tableName);
+    }
+
+    public WorkerThread(WorkerCQL workerCQL, WorkerTransport workerTransport, Consumer consumer,
+                        GenerationMetadata generationMetadata, Clock clock, TableName tableName) {
+        this(workerCQL, workerTransport, consumer, generationMetadata, clock, Collections.singleton(tableName));
+    }
+
+    @Override
+    public void close() {
+        if (this.worker != null) {
+            this.worker.stop();
+        }
+        if (this.workerRunFuture != null) {
+            try {
+                Throwable t = this.workerRunFuture.get(FUTURE_GET_TIMEOUT, TimeUnit.MILLISECONDS);
+                if (t != null) {
+                    fail("Worker run future threw exception", t);
+                }
+            } catch (Exception e) {
+                fail("Could not successfully get() worker future", e);
+            }
+        }
+    }
+}

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/transport/MockWorkerTransport.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/transport/MockWorkerTransport.java
@@ -1,0 +1,43 @@
+package com.scylladb.cdc.transport;
+
+import com.scylladb.cdc.model.TaskId;
+import com.scylladb.cdc.model.worker.TaskState;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.stream.Collectors;
+
+public class MockWorkerTransport implements WorkerTransport {
+    private Map<TaskId, TaskState> taskStates = new ConcurrentHashMap<>();
+
+    private List<AbstractMap.SimpleEntry<TaskId, TaskState>> setStatesInvocations = new CopyOnWriteArrayList<>();
+    private List<AbstractMap.SimpleEntry<TaskId, TaskState>> moveStateToNextWindowInvocations = new CopyOnWriteArrayList<>();
+
+    @Override
+    public Map<TaskId, TaskState> getTaskStates(Set<TaskId> tasks) {
+        return Collections.unmodifiableMap(taskStates);
+    }
+
+    @Override
+    public void setState(TaskId task, TaskState newState) {
+        taskStates.put(task, newState);
+        setStatesInvocations.add(new AbstractMap.SimpleEntry<>(task, newState));
+    }
+
+    @Override
+    public void moveStateToNextWindow(TaskId task, TaskState newState) {
+        taskStates.put(task, newState);
+        moveStateToNextWindowInvocations.add(new AbstractMap.SimpleEntry<>(task, newState));
+    }
+
+    public List<TaskState> getSetStateInvocations(TaskId taskId) {
+        return setStatesInvocations.stream().filter(t -> t.getKey().equals(taskId))
+                .map(AbstractMap.SimpleEntry::getValue).collect(Collectors.toList());
+    }
+
+    public List<TaskState> getMoveStateToNextWindowInvocations(TaskId taskId) {
+        return moveStateToNextWindowInvocations.stream().filter(t -> t.getKey().equals(taskId))
+                .map(AbstractMap.SimpleEntry::getValue).collect(Collectors.toList());
+    }
+}


### PR DESCRIPTION
This PR contains the unit tests for Worker (and the required "infrastructure" to do so).

First few commits change minor things required by later commits, like missing `equals()` in `Task` or support for providing your own `Clock` for `Worker`.

Next, `MockWorkerCQL` class is added. This class implements `WorkerCQL` for in-memory list of `RawChange`. Therefore, you can easily generate `RawChange`s and imitate Scylla's behaviour using this new class.

`MockWorkerCQL` also allows you to dynamically plug in error injectors, to simulate CQL failures.

Next, `MockWorkerTransport` class is added, which is in-memory store of offsets.

Finally, Worker unit tests are added. These tests verify such functionality:
1. TaskState saving to Transport
2. Handling of exceptions
3. Reading back TaskStates from Transport
4. Trimming generations based on TTL
5. Reading of windows and changes

The added tests finish in under 1 second. One important scenario is missing from the tests: failure within a batch in CDC log, as this is currently not handled correctly by the library.