### PR TITLE
API design improvements

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/ChangeSchema.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/ChangeSchema.java
@@ -260,24 +260,6 @@ public class ChangeSchema {
             return baseIsNonfrozenList;
         }
 
-        public ColumnDefinition getDeletedColumn(ChangeSchema schema) {
-            if (baseTableDataType == null) {
-                throw new IllegalStateException("Cannot get deleted elements column for CDC columns.");
-            }
-            return schema.getColumnDefinition("cdc$deleted_" + columnName);
-        }
-
-        public ColumnDefinition getDeletedElementsColumn(ChangeSchema schema) {
-            if (baseTableDataType == null) {
-                throw new IllegalStateException("Cannot get deleted elements column for CDC columns.");
-            }
-            if (baseTableDataType.isAtomic()) {
-                throw new IllegalStateException(
-                        "Cannot get deleted elements column for frozen or non-collection columns.");
-            }
-            return schema.getColumnDefinition("cdc$deleted_elements_" + columnName);
-        }
-
         @Override
         public int hashCode() {
             return Objects.hash(baseIsNonfrozenList, baseTableColumnType, baseTableDataType, cdcLogDataType, columnName,
@@ -329,6 +311,22 @@ public class ChangeSchema {
         // TODO - do not linearly search
         Optional<ColumnDefinition> result = columnDefinitions.stream().filter(c -> c.getColumnName().equals(columnName)).findFirst();
         return result.orElseThrow(() -> new IllegalArgumentException("Column name " + columnName + " is not present in change schema."));
+    }
+
+    public ColumnDefinition getDeletedColumnDefinition(String columnName) {
+        return getColumnDefinition("cdc$deleted_" + columnName);
+    }
+
+    public ColumnDefinition getDeletedColumnDefinition(ColumnDefinition c) {
+        return getDeletedColumnDefinition(c.getColumnName());
+    }
+
+    public ColumnDefinition getDeletedElementsColumnDefinition(String columnName) {
+        return getColumnDefinition("cdc$deleted_elements_" + columnName);
+    }
+
+    public ColumnDefinition getDeletedElementsColumnDefinition(ColumnDefinition c) {
+        return getDeletedElementsColumnDefinition(c);
     }
 
     // TODO - add getTableName() here.

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/ChangeSchema.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/ChangeSchema.java
@@ -32,6 +32,11 @@ public class ChangeSchema {
         SMALLINT,
         TINYINT,
         DURATION,
+
+        // All types from this point
+        // are non-atomic types. This order
+        // is important, as this fact is used in
+        // isAtomic.
         LIST,
         MAP,
         SET,

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/ChangeSchema.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/ChangeSchema.java
@@ -213,15 +213,13 @@ public class ChangeSchema {
         private final DataType cdcLogDataType;
         private final DataType baseTableDataType;
         private final ColumnType baseTableColumnType;
-        private final boolean baseIsNonfrozenList;
 
-        public ColumnDefinition(String columnName, int index, DataType cdcLogDataType, DataType baseTableDataType, ColumnType baseTableColumnType, boolean baseIsNonfrozenList) {
+        public ColumnDefinition(String columnName, int index, DataType cdcLogDataType, DataType baseTableDataType, ColumnType baseTableColumnType) {
             this.columnName = columnName;
             this.index = index;
             this.cdcLogDataType = cdcLogDataType;
             this.baseTableDataType = baseTableDataType;
             this.baseTableColumnType = baseTableColumnType;
-            this.baseIsNonfrozenList = baseIsNonfrozenList;
         }
 
         public int getIndex() {
@@ -251,19 +249,9 @@ public class ChangeSchema {
             return baseTableColumnType;
         }
 
-        public boolean baseIsNonfrozenList() {
-            if (isCdcColumn()) {
-                // TODO: actually, this may make sense for cdc$deleted_ and cdc$deleted_elements_ columns as well
-                // but ensure that whoever constructs `ColumnDefinition` passes a correct value
-                throw new IllegalStateException("Cannot get base table column type for CDC columns.");
-            }
-            return baseIsNonfrozenList;
-        }
-
         @Override
         public int hashCode() {
-            return Objects.hash(baseIsNonfrozenList, baseTableColumnType, baseTableDataType, cdcLogDataType, columnName,
-                    index);
+            return Objects.hash(baseTableColumnType, baseTableDataType, cdcLogDataType, columnName, index);
         }
 
         @Override
@@ -275,7 +263,7 @@ public class ChangeSchema {
                 return false;
             }
             ColumnDefinition other = (ColumnDefinition) obj;
-            return baseIsNonfrozenList == other.baseIsNonfrozenList && baseTableColumnType == other.baseTableColumnType
+            return baseTableColumnType == other.baseTableColumnType
                     && Objects.equals(baseTableDataType, other.baseTableDataType)
                     && Objects.equals(cdcLogDataType, other.cdcLogDataType)
                     && Objects.equals(columnName, other.columnName) && index == other.index;

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/RawChange.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/RawChange.java
@@ -2,9 +2,11 @@ package com.scylladb.cdc.model.worker;
 
 import java.nio.ByteBuffer;
 import java.util.Iterator;
+import java.util.Set;
 import java.util.stream.Stream;
 
 import com.scylladb.cdc.model.worker.cql.Cell;
+import com.scylladb.cdc.model.worker.cql.Field;
 
 /*
  * Represents a single CDC log row,
@@ -98,6 +100,15 @@ public interface RawChange extends Iterable<Cell> {
         // if type == null, this will throw
         Boolean value = getCell(c.getDeletedColumn(getSchema())).getBoolean();
         return value != null && value;
+    }
+
+    default Set<Field> getDeletedElements(String columnName) {
+        return getDeletedElements(getSchema().getColumnDefinition(columnName));
+    }
+
+    default Set<Field> getDeletedElements(ChangeSchema.ColumnDefinition c) {
+        ChangeSchema.ColumnDefinition deletedElementsColumnDefinition = getSchema().getDeletedElementsColumnDefinition(c);
+        return getCell(deletedElementsColumnDefinition).getSet();
     }
 
     @Deprecated

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/RawChange.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/RawChange.java
@@ -93,11 +93,6 @@ public interface RawChange extends Iterable<Cell> {
     }
 
     default boolean isDeleted(ChangeSchema.ColumnDefinition c) {
-        ChangeSchema.DataType type = c.getBaseTableDataType();
-        if (type != null && type.isAtomic()) {
-            return isNull(c);
-        }
-        // if type == null, this will throw
         Boolean value = getCell(c.getDeletedColumn(getSchema())).getBoolean();
         return value != null && value;
     }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/RawChange.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/RawChange.java
@@ -93,7 +93,8 @@ public interface RawChange extends Iterable<Cell> {
     }
 
     default boolean isDeleted(ChangeSchema.ColumnDefinition c) {
-        Boolean value = getCell(c.getDeletedColumn(getSchema())).getBoolean();
+        ChangeSchema.ColumnDefinition deletedColumnDefinition = getSchema().getDeletedColumnDefinition(c);
+        Boolean value = getCell(deletedColumnDefinition).getBoolean();
         return value != null && value;
     }
 

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/cql/Cell.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/cql/Cell.java
@@ -7,12 +7,6 @@ import com.scylladb.cdc.model.worker.ChangeSchema;
 
 public interface Cell extends Field {
     ChangeSchema.ColumnDefinition getColumnDefinition();
-
-    Set<Field> getDeletedElements();
-
-    boolean hasDeletedElements();
-
-    boolean isDeleted();
     
     ByteBuffer getUnsafeBytes();
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/cql/Cell.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/cql/Cell.java
@@ -8,5 +8,5 @@ import com.scylladb.cdc.model.worker.ChangeSchema;
 public interface Cell extends Field {
     ChangeSchema.ColumnDefinition getColumnDefinition();
     
-    ByteBuffer getUnsafeBytes();
+    ByteBuffer getAsUnsafeBytes();
 }

--- a/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Cell.java
+++ b/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Cell.java
@@ -32,7 +32,7 @@ class Driver3Cell implements Cell {
     }
 
     @Override
-    public ByteBuffer getUnsafeBytes() {
+    public ByteBuffer getAsUnsafeBytes() {
         return change.getUnsafeBytes(columnDefinition);
     }
 

--- a/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Cell.java
+++ b/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Cell.java
@@ -31,28 +31,6 @@ class Driver3Cell implements Cell {
         return columnDefinition.getCdcLogDataType();
     }
 
-    @SuppressWarnings("unchecked")
-    @Override
-    public Set<Field> getDeletedElements() {
-        if (!hasDeletedElements()) {
-            return null;
-        }
-        return (Set<Field>) change.getAsObject(columnDefinition.getDeletedElementsColumn(change.getSchema()));
-    }
-
-    @Override
-    public boolean hasDeletedElements() {
-        if (!columnDefinition.getBaseTableDataType().isAtomic()) {
-            return false;
-        }
-        return !change.isNull(columnDefinition.getDeletedElementsColumn(change.getSchema()));
-    }
-
-    @Override
-    public boolean isDeleted() {
-        return change.isDeleted(columnDefinition);
-    }
-
     @Override
     public ByteBuffer getUnsafeBytes() {
         return change.getUnsafeBytes(columnDefinition);

--- a/scylla-cdc-replicator/src/main/java/com/scylladb/cdc/replicator/operations/preimage/PreImageOperationHandler.java
+++ b/scylla-cdc-replicator/src/main/java/com/scylladb/cdc/replicator/operations/preimage/PreImageOperationHandler.java
@@ -107,9 +107,14 @@ public class PreImageOperationHandler implements CdcOperationHandler {
         return CompletableFuture.completedFuture(null);
     }
 
+    private static boolean isBaseTypeNonfrozenList(ChangeSchema.ColumnDefinition columnDefinition) {
+        ChangeSchema.DataType cellBaseType = columnDefinition.getBaseTableDataType();
+        return cellBaseType.getCqlType() == ChangeSchema.CqlType.LIST && !cellBaseType.isFrozen();
+    }
+
     /* Casts the given preimage cell to a value as if it would appear in a standard CQL read from the base table. */
     private static Object asObject(Cell preimageCell) {
-        if (preimageCell.getColumnDefinition().baseIsNonfrozenList()) {
+        if (isBaseTypeNonfrozenList(preimageCell.getColumnDefinition())) {
             // The keys (timeuuids) define the order of values in a non-frozen list
             // and we store our maps in a way that preserves the order of keys returned by the driver.
             // To get the list as it appears in a CQL base table read, we simply drop all keys:
@@ -121,7 +126,7 @@ public class PreImageOperationHandler implements CdcOperationHandler {
     // hack: we're using ChangeSchema.DataType to represent base table types
     private static ChangeSchema.DataType calculateBaseType(ChangeSchema.ColumnDefinition colDef) {
         ChangeSchema.DataType logType = colDef.getCdcLogDataType();
-        if (colDef.baseIsNonfrozenList()) {
+        if (isBaseTypeNonfrozenList(colDef)) {
             return ChangeSchema.DataType.list(logType.getTypeArguments().get(1));
         }
         return logType;


### PR DESCRIPTION
This pull request focuses on a few small API design improvements. It strives to better organize the API and to maintain a proper structure/hierarchy of it.

### Getting other `Cell`s from a `Cell` (commit 1, 2)
Remove getters that return other `Cell`s from a `Cell`. The main reason is design-wise: `Cell` describes only a single `Cell`, not an entire row. The logic to fetch `Cell`s should be in `RawChange`. 

Those getters provided a hope of easier parsing of Scylla CDC changes. But adding those getters is only "1%" of effort required to properly parse non-frozen collection mutations. The logic required to do so is much larger and is in no way addressed by those getters. However, my planned higher-level API provides much more comprehensive way to consume non-frozen collection changes. 

"Sprinkling" getters around the codebase might seem like a good idea, for example: `getDataType()` vs `getColumnDefinition().getBaseDataType()` seems like an improvement, but a side-effect of such patchwork design is that a structure of API is lost - you can get the same information in N ways, so if you want to access some property where should you go? Such getters also remove the "hierarchical" design of the API.

The next commit adds a `getDeletedElements()` getter to `RawChange` to allow for easy access to this column. I belive that this getter is at a correct abstraction level.

### Rename getUnsafeBytes to getAsUnsafeBytes (commit 3)

Rename `getUnsafeBytes()` to `getAsUnsafeBytes()`. `Cell` and `Field` interfaces provide a wide variety of getters, for example: `getBytes()`, `getInt()`, `getSet()`, `getDouble()`. There are two getters that have different meaning:

1. `getAsObject()` - return the value of `Cell`/`Field` as untyped `Object`
2. `getAsUnsafeBytes()` - return the value of `Cell`/`Field` as the driver received it in bytes. This is different than `getBytes()` which returns a value of `BLOB` column

The `getAs*` naming strives to differentiate itself from other `get*` methods.  Even though `getUnsafeBytes` terminology is used in the Java Driver, I believe that `getAsUnsafeBytes()` better describes what this method does. `getUnsafeBytes()` could suggest that there is a "unsafe bytes" type of column in Scylla.

### Fix isDeleted() implementation (commit 4)
All columns, including: atomic columns, frozen collections, non-frozen collections all have a `cdc$deleted_` column. The only exception to this rule are the partition/clustering keys.

The previous implementation of `isDeleted()` wrongly assumed that atomic cells don't have a `cdc$deleted_` column. I couldn't think of any potential usage of such implementation and moreover it changed the previous semantics.

### Add comment in CqlType enum (commit 5)
`DataType::isAtomic` method uses the order of CQL types in `CqlType` enum to determine which types can be non-atomic. This order was not documented, which could result in someone erroneously modifying it in the future.

### Remove other column getters from ChangeSchema (commit 6)
Delete getters that return other column definitions from a `ColumnDefinition`. The previous API required you to pass `ChangeSchema` object ("parent" object) to the `ChangeSchema.ColumnDefinition` class ("child" object). Due to this design, it was quite cumbersome:

```
rawChange.getSchema().getColumnDefinition("mycell").getDeletedColumn(rawChange.getSchema())
```

A `ColumnDefinition` class should not know anything about any other columns. The responsibility should be in `ChangeSchema`, which manages multiple columns. As a analogy, there should not be a `getColumnBaseType` method in `ChangeSchema`, as this is a responsibility of `ColumnDefinition`.

Therefore, `getDeletedColumn` and `getDeletedElementsColumn` are moved out to `ChangeSchema`. The example above now looks like this:

```
rawChange.getSchema().getDeletedColumnDefinition("mycell")
```

### Remove baseIsNonfrozenList() (commit 7)
`baseIsNonfrozenList()` was introduced as a bit of hack for replicator.

As now `ChangeSchema` has `baseTableDataType`, `baseIsNonfrozenList` is not needed, as it can be inferred from `baseTableDataType` in much cleaner way.
