### PR TITLE
Add MockRawChange class

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/RawChange.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/RawChange.java
@@ -4,6 +4,7 @@ import java.nio.ByteBuffer;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
+import com.scylladb.cdc.model.StreamId;
 import com.scylladb.cdc.model.worker.cql.Cell;
 
 /*
@@ -37,7 +38,10 @@ public interface RawChange extends Iterable<Cell> {
         }
     }
 
-    ChangeId getId();
+    default ChangeId getId() {
+        return new ChangeId(new StreamId(getCell("cdc$stream_id").getBytes()),
+                new ChangeTime(getCell("cdc$time").getUUID()));
+    }
 
     default OperationType getOperationType() {
         Byte operation = getCell("cdc$operation").getByte();

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/MockRawChange.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/MockRawChange.java
@@ -1,0 +1,93 @@
+package com.scylladb.cdc.model.worker;
+
+import com.scylladb.cdc.model.worker.cql.Cell;
+import com.scylladb.cdc.model.worker.cql.Field;
+
+import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public class MockRawChange implements RawChange {
+    private final ChangeSchema changeSchema;
+    private final Map<String, Object> columnValues;
+
+    public MockRawChange(ChangeSchema changeSchema, Map<String, Object> columnValues) {
+        this.changeSchema = changeSchema;
+        this.columnValues = columnValues;
+    }
+
+    @Override
+    public ChangeSchema getSchema() {
+        return changeSchema;
+    }
+
+    @Override
+    public Object getAsObject(ChangeSchema.ColumnDefinition c) {
+        return columnValues.get(c.getColumnName());
+    }
+
+    @Override
+    public Cell getCell(ChangeSchema.ColumnDefinition c) {
+        return new Cell() {
+            @Override
+            public ChangeSchema.ColumnDefinition getColumnDefinition() {
+                return c;
+            }
+
+            @Override
+            public Set<Field> getDeletedElements() {
+                throw new UnsupportedOperationException("Not implemented yet");
+            }
+
+            @Override
+            public boolean hasDeletedElements() {
+                throw new UnsupportedOperationException("Not implemented yet");
+            }
+
+            @Override
+            public boolean isDeleted() {
+                throw new UnsupportedOperationException("Not implemented yet");
+            }
+
+            @Override
+            public ByteBuffer getUnsafeBytes() {
+                throw new UnsupportedOperationException("Not implemented yet");
+            }
+
+            @Override
+            public Object getAsObject() {
+                return MockRawChange.this.getAsObject(c);
+            }
+
+            @Override
+            public ChangeSchema.DataType getDataType() {
+                return c.getCdcLogDataType();
+            }
+        };
+    }
+
+    @Override
+    public boolean isNull(ChangeSchema.ColumnDefinition c) {
+        return getAsObject(c) == null;
+    }
+
+    @Override
+    public ByteBuffer getUnsafeBytes(ChangeSchema.ColumnDefinition c) {
+        throw new UnsupportedOperationException("Not implemented yet");
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        MockRawChange cells = (MockRawChange) o;
+        return changeSchema.equals(cells.changeSchema) &&
+                columnValues.equals(cells.columnValues);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(changeSchema, columnValues);
+    }
+}

--- a/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3RawChange.java
+++ b/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3RawChange.java
@@ -25,12 +25,6 @@ public final class Driver3RawChange implements RawChange {
     }
 
     @Override
-    public ChangeId getId() {
-        return new ChangeId(new StreamId(row.getBytes(quoteIfNecessary("cdc$stream_id"))),
-                new ChangeTime(row.getUUID(quoteIfNecessary("cdc$time"))));
-    }
-
-    @Override
     public ChangeSchema getSchema() {
         return schema;
     }


### PR DESCRIPTION
Add a new `MockRawChange` class which implements `RawChange` and allows us to construct an artificial `RawChange` without having to get one from the driver.

This will allow us write tests that check different functionalities of  the library without having to connect to Scylla.