### PR TITLE
Rename getUnsafeBytes to getAsUnsafeBytes

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/cql/Cell.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/cql/Cell.java
@@ -14,5 +14,21 @@ public interface Cell extends Field {
 
     boolean isDeleted();
     
-    ByteBuffer getUnsafeBytes();
+    /**
+     * Returns the value of a binary representation of this cell as a <code>ByteBuffer</code>.
+     * <p>
+     * This method returns a binary representation of this cell as it was received
+     * by the underlying Scylla driver. This representation may vary between different
+     * versions of this library and <code>WorkerCQL</code> implementations.
+     * <p>
+     * This method can be called for any type of column, not only <code>BLOB</code>.
+     * If you want to read the value of a <code>BLOB</code> column, please use the
+     * {@link Field#getBytes() getBytes} method.
+     * <p>
+     * If a value of this cell is <code>NULL</code>, this method returns <code>null</code>.
+     *
+     * @return the value of a binary representation of this cell. If the value of this cell
+     *         is <code>NULL</code>, <code>null</code> is returned.
+     */
+    ByteBuffer getAsUnsafeBytes();
 }

--- a/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Cell.java
+++ b/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Cell.java
@@ -54,7 +54,7 @@ class Driver3Cell implements Cell {
     }
 
     @Override
-    public ByteBuffer getUnsafeBytes() {
+    public ByteBuffer getAsUnsafeBytes() {
         return change.getUnsafeBytes(columnDefinition);
     }
 


### PR DESCRIPTION
Rename `getUnsafeBytes()` to `getAsUnsafeBytes()`. `Cell` and `Field` interfaces provide a wide variety of getters, for example: `getBytes()`, `getInt()`, `getSet()`, `getDouble()`. There are two getters that have different meaning:

1. `getAsObject()` - return the value of `Cell`/`Field` as untyped `Object`
2. `getAsUnsafeBytes()` - return the value of `Cell`/`Field` as the driver received it in bytes. This is different than `getBytes()` which returns a value of `BLOB` column

The `getAs*` naming strives to differentiate itself from other `get*` methods.  Even though `getUnsafeBytes` terminology is used in the Java Driver, I believe that `getAsUnsafeBytes()` better describes what this method does. `getUnsafeBytes()` could suggest that there is a "unsafe bytes" type of column in Scylla.