### PR TITLE
Fix RawChange::isDeleted() implementation and add its test

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/RawChange.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/RawChange.java
@@ -129,11 +129,6 @@ public interface RawChange extends Iterable<Cell> {
     }
 
     default boolean isDeleted(ChangeSchema.ColumnDefinition c) {
-        ChangeSchema.DataType type = c.getBaseTableDataType();
-        if (type != null && type.isAtomic()) {
-            return isNull(c);
-        }
-        // if type == null, this will throw
         Boolean value = getCell(c.getDeletedColumn(getSchema())).getBoolean();
         return value != null && value;
     }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/RawChange.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/RawChange.java
@@ -124,12 +124,56 @@ public interface RawChange extends Iterable<Cell> {
      */
     ByteBuffer getAsUnsafeBytes(ChangeSchema.ColumnDefinition columnDefinition);
 
+    /**
+     * Returns the boolean value of the deleted column for the given column name.
+     * <p>
+     * This method returns the value of the <code>cdc$deleted_</code> column for
+     * the given column name. It is only relevant for the regular columns
+     * (columns not in a primary key) of the base table, because only
+     * those columns have a corresponding deleted column.
+     * <p>
+     * If a column in a delta row is <code>NULL</code> and this method returns <code>true</code> for this
+     * column, it means that a <code>NULL</code> value was written in this CDC
+     * operation.
+     * <p>
+     * The meaning of the deleted column is different for preimage rows
+     * and mutations of non-frozen collections. See <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-advanced-types/">Advanced column types</a>
+     * and <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-preimages/">Preimages and postimages</a> pages for more details.
+     *
+     * @see <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-basic-operations/">Basic operations in CDC</a>
+     * @see <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-advanced-types/">Advanced column types</a>
+     * @see <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-preimages/">Preimages and postimages</a>
+     * @param columnName the column name for which to retrieve the deleted column.
+     * @return the boolean value of the deleted column for the given column.
+     */
     default boolean isDeleted(String columnName) {
         return isDeleted(getSchema().getColumnDefinition(columnName));
     }
 
-    default boolean isDeleted(ChangeSchema.ColumnDefinition c) {
-        Boolean value = getCell(c.getDeletedColumn(getSchema())).getBoolean();
+    /**
+     * Returns the boolean value of the deleted column for the given column.
+     * <p>
+     * This method returns the value of the <code>cdc$deleted_</code> column for
+     * the given column. It is only relevant for the regular columns
+     * (columns not in a primary key) of the base table, because only
+     * those columns have a corresponding deleted column.
+     * <p>
+     * If a column in a delta row is <code>NULL</code> and this method returns <code>true</code> for this
+     * column, it means that a <code>NULL</code> value was written in this CDC
+     * operation.
+     * <p>
+     * The meaning of the deleted column is different for preimage rows
+     * and mutations of non-frozen collections. See <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-advanced-types/">Advanced column types</a>
+     * and <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-preimages/">Preimages and postimages</a> pages for more details.
+     *
+     * @see <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-basic-operations/">Basic operations in CDC</a>
+     * @see <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-advanced-types/">Advanced column types</a>
+     * @see <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-preimages/">Preimages and postimages</a>
+     * @param columnDefinition the column for which to retrieve the deleted column.
+     * @return the boolean value of the deleted column for the given column.
+     */
+    default boolean isDeleted(ChangeSchema.ColumnDefinition columnDefinition) {
+        Boolean value = getCell(columnDefinition.getDeletedColumn(getSchema())).getBoolean();
         return value != null && value;
     }
 

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/ChangeSchemaTest.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/ChangeSchemaTest.java
@@ -87,9 +87,9 @@ public class ChangeSchemaTest {
     ));
 
     // CDC table for:
-    // CREATE TABLE ks.unfrozen_collections(pk int, ck int, v set<int>, v2 list<int>, v3 map<double, text>, v4 tuple<inet, int>, PRIMARY KEY(pk, ck)) WITH cdc = {'enabled': true};
+    // CREATE TABLE ks.nonfrozen_collections(pk int, ck int, v set<int>, v2 list<int>, v3 map<double, text>, v4 tuple<inet, int>, PRIMARY KEY(pk, ck)) WITH cdc = {'enabled': true};
     //
-    // CREATE TABLE ks.unfrozen_collections_scylla_cdc_log (
+    // CREATE TABLE ks.nonfrozen_collections_scylla_cdc_log (
     //    "cdc$stream_id" blob,
     //    "cdc$time" timeuuid,
     //    "cdc$batch_seq_no" int,
@@ -114,14 +114,14 @@ public class ChangeSchemaTest {
     private static final ChangeSchema.DataType FROZEN_SET_TIMEUUID = new ChangeSchema.DataType(ChangeSchema.CqlType.SET, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.TIMEUUID)), true);
     private static final ChangeSchema.DataType FROZEN_SET_DOUBLE = new ChangeSchema.DataType(ChangeSchema.CqlType.SET, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.DOUBLE)), true);
 
-    private static final ChangeSchema.DataType UNFROZEN_SET_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.SET, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), false);
-    private static final ChangeSchema.DataType UNFROZEN_LIST_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.LIST, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), false);
-    private static final ChangeSchema.DataType UNFROZEN_MAP_DOUBLE_TEXT = new ChangeSchema.DataType(ChangeSchema.CqlType.MAP, Lists.newArrayList(
+    private static final ChangeSchema.DataType NONFROZEN_SET_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.SET, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), false);
+    private static final ChangeSchema.DataType NONFROZEN_LIST_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.LIST, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), false);
+    private static final ChangeSchema.DataType NONFROZEN_MAP_DOUBLE_TEXT = new ChangeSchema.DataType(ChangeSchema.CqlType.MAP, Lists.newArrayList(
             new ChangeSchema.DataType(ChangeSchema.CqlType.DOUBLE), new ChangeSchema.DataType(ChangeSchema.CqlType.TEXT)), false);
-    private static final ChangeSchema.DataType UNFROZEN_TUPLE_INET_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.TUPLE, Lists.newArrayList(
+    private static final ChangeSchema.DataType NONFROZEN_TUPLE_INET_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.TUPLE, Lists.newArrayList(
             new ChangeSchema.DataType(ChangeSchema.CqlType.INET), new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), false);
 
-    private static final ChangeSchema TEST_SCHEMA_UNFROZEN_COLLECTIONS = new ChangeSchema(Lists.newArrayList(
+    private static final ChangeSchema TEST_SCHEMA_NONFROZEN_COLLECTIONS = new ChangeSchema(Lists.newArrayList(
             new ChangeSchema.ColumnDefinition("cdc$stream_id", 0, new ChangeSchema.DataType(ChangeSchema.CqlType.BLOB), null, null, false),
             new ChangeSchema.ColumnDefinition("cdc$time", 1, new ChangeSchema.DataType(ChangeSchema.CqlType.TIMEUUID), null, null, false),
             new ChangeSchema.ColumnDefinition("cdc$batch_seq_no", 2, new ChangeSchema.DataType(ChangeSchema.CqlType.INT), null, null, false),
@@ -137,10 +137,10 @@ public class ChangeSchemaTest {
             new ChangeSchema.ColumnDefinition("cdc$ttl", 12, new ChangeSchema.DataType(ChangeSchema.CqlType.BIGINT), null, null, false),
             new ChangeSchema.ColumnDefinition("ck", 13, new ChangeSchema.DataType(ChangeSchema.CqlType.INT), new ChangeSchema.DataType(ChangeSchema.CqlType.INT), ChangeSchema.ColumnType.CLUSTERING_KEY, false),
             new ChangeSchema.ColumnDefinition("pk", 14, new ChangeSchema.DataType(ChangeSchema.CqlType.INT), new ChangeSchema.DataType(ChangeSchema.CqlType.INT), ChangeSchema.ColumnType.PARTITION_KEY, false),
-            new ChangeSchema.ColumnDefinition("v", 15, FROZEN_SET_INT, UNFROZEN_SET_INT, ChangeSchema.ColumnType.REGULAR, false),
-            new ChangeSchema.ColumnDefinition("v2", 16, FROZEN_LIST_INT, UNFROZEN_LIST_INT, ChangeSchema.ColumnType.REGULAR, true),
-            new ChangeSchema.ColumnDefinition("v3", 17, FROZEN_MAP_DOUBLE_TEXT, UNFROZEN_MAP_DOUBLE_TEXT, ChangeSchema.ColumnType.REGULAR, false),
-            new ChangeSchema.ColumnDefinition("v4", 18, FROZEN_TUPLE_INET_INT, UNFROZEN_TUPLE_INET_INT, ChangeSchema.ColumnType.REGULAR, false)
+            new ChangeSchema.ColumnDefinition("v", 15, FROZEN_SET_INT, NONFROZEN_SET_INT, ChangeSchema.ColumnType.REGULAR, false),
+            new ChangeSchema.ColumnDefinition("v2", 16, FROZEN_LIST_INT, NONFROZEN_LIST_INT, ChangeSchema.ColumnType.REGULAR, true),
+            new ChangeSchema.ColumnDefinition("v3", 17, FROZEN_MAP_DOUBLE_TEXT, NONFROZEN_MAP_DOUBLE_TEXT, ChangeSchema.ColumnType.REGULAR, false),
+            new ChangeSchema.ColumnDefinition("v4", 18, FROZEN_TUPLE_INET_INT, NONFROZEN_TUPLE_INET_INT, ChangeSchema.ColumnType.REGULAR, false)
     ));
 
     @Test
@@ -165,15 +165,15 @@ public class ChangeSchemaTest {
         // frozen<tuple<inet, int>>
         assertTrue(FROZEN_TUPLE_INET_INT.isAtomic());
 
-        // Unfrozen types:
+        // Nonfrozen types:
 
         // set<int>
-        assertFalse(UNFROZEN_SET_INT.isAtomic());
+        assertFalse(NONFROZEN_SET_INT.isAtomic());
         // list<int>
-        assertFalse(UNFROZEN_LIST_INT.isAtomic());
+        assertFalse(NONFROZEN_LIST_INT.isAtomic());
         // map<double, text>
-        assertFalse(UNFROZEN_MAP_DOUBLE_TEXT.isAtomic());
+        assertFalse(NONFROZEN_MAP_DOUBLE_TEXT.isAtomic());
         // tuple<inet, int>
-        assertFalse(UNFROZEN_TUPLE_INET_INT.isAtomic());
+        assertFalse(NONFROZEN_TUPLE_INET_INT.isAtomic());
     }
 }

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/ChangeSchemaTest.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/ChangeSchemaTest.java
@@ -25,7 +25,7 @@ public class ChangeSchemaTest {
     //    v int,
     //    PRIMARY KEY ("cdc$stream_id", "cdc$time", "cdc$batch_seq_no")
     // )
-    private static final ChangeSchema TEST_SCHEMA_SIMPLE = new ChangeSchema(Lists.newArrayList(
+    public static final ChangeSchema TEST_SCHEMA_SIMPLE = new ChangeSchema(Lists.newArrayList(
             new ChangeSchema.ColumnDefinition("cdc$stream_id", 0, new ChangeSchema.DataType(ChangeSchema.CqlType.BLOB), null, null, false),
             new ChangeSchema.ColumnDefinition("cdc$time", 1, new ChangeSchema.DataType(ChangeSchema.CqlType.TIMEUUID), null, null, false),
             new ChangeSchema.ColumnDefinition("cdc$batch_seq_no", 2, new ChangeSchema.DataType(ChangeSchema.CqlType.INT), null, null, false),
@@ -60,14 +60,14 @@ public class ChangeSchemaTest {
     //    v4 frozen<tuple<inet, int>>,
     //    PRIMARY KEY ("cdc$stream_id", "cdc$time", "cdc$batch_seq_no")
     // )
-    private static final ChangeSchema.DataType FROZEN_SET_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.SET, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), true);
-    private static final ChangeSchema.DataType FROZEN_LIST_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.LIST, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), true);
-    private static final ChangeSchema.DataType FROZEN_MAP_DOUBLE_TEXT = new ChangeSchema.DataType(ChangeSchema.CqlType.MAP, Lists.newArrayList(
+    public static final ChangeSchema.DataType FROZEN_SET_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.SET, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), true);
+    public static final ChangeSchema.DataType FROZEN_LIST_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.LIST, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), true);
+    public static final ChangeSchema.DataType FROZEN_MAP_DOUBLE_TEXT = new ChangeSchema.DataType(ChangeSchema.CqlType.MAP, Lists.newArrayList(
             new ChangeSchema.DataType(ChangeSchema.CqlType.DOUBLE), new ChangeSchema.DataType(ChangeSchema.CqlType.TEXT)), true);
-    private static final ChangeSchema.DataType FROZEN_TUPLE_INET_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.TUPLE, Lists.newArrayList(
+    public static final ChangeSchema.DataType FROZEN_TUPLE_INET_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.TUPLE, Lists.newArrayList(
             new ChangeSchema.DataType(ChangeSchema.CqlType.INET), new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), true);
 
-    private static final ChangeSchema TEST_SCHEMA_FROZEN_COLLECTIONS = new ChangeSchema(Lists.newArrayList(
+    public static final ChangeSchema TEST_SCHEMA_FROZEN_COLLECTIONS = new ChangeSchema(Lists.newArrayList(
             new ChangeSchema.ColumnDefinition("cdc$stream_id", 0, new ChangeSchema.DataType(ChangeSchema.CqlType.BLOB), null, null, false),
             new ChangeSchema.ColumnDefinition("cdc$time", 1, new ChangeSchema.DataType(ChangeSchema.CqlType.TIMEUUID), null, null, false),
             new ChangeSchema.ColumnDefinition("cdc$batch_seq_no", 2, new ChangeSchema.DataType(ChangeSchema.CqlType.INT), null, null, false),
@@ -111,17 +111,17 @@ public class ChangeSchemaTest {
     //    v4 frozen<tuple<inet, int>>,
     //    PRIMARY KEY ("cdc$stream_id", "cdc$time", "cdc$batch_seq_no")
     // )
-    private static final ChangeSchema.DataType FROZEN_SET_TIMEUUID = new ChangeSchema.DataType(ChangeSchema.CqlType.SET, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.TIMEUUID)), true);
-    private static final ChangeSchema.DataType FROZEN_SET_DOUBLE = new ChangeSchema.DataType(ChangeSchema.CqlType.SET, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.DOUBLE)), true);
+    public static final ChangeSchema.DataType FROZEN_SET_TIMEUUID = new ChangeSchema.DataType(ChangeSchema.CqlType.SET, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.TIMEUUID)), true);
+    public static final ChangeSchema.DataType FROZEN_SET_DOUBLE = new ChangeSchema.DataType(ChangeSchema.CqlType.SET, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.DOUBLE)), true);
 
-    private static final ChangeSchema.DataType NONFROZEN_SET_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.SET, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), false);
-    private static final ChangeSchema.DataType NONFROZEN_LIST_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.LIST, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), false);
-    private static final ChangeSchema.DataType NONFROZEN_MAP_DOUBLE_TEXT = new ChangeSchema.DataType(ChangeSchema.CqlType.MAP, Lists.newArrayList(
+    public static final ChangeSchema.DataType NONFROZEN_SET_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.SET, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), false);
+    public static final ChangeSchema.DataType NONFROZEN_LIST_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.LIST, Collections.singletonList(new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), false);
+    public static final ChangeSchema.DataType NONFROZEN_MAP_DOUBLE_TEXT = new ChangeSchema.DataType(ChangeSchema.CqlType.MAP, Lists.newArrayList(
             new ChangeSchema.DataType(ChangeSchema.CqlType.DOUBLE), new ChangeSchema.DataType(ChangeSchema.CqlType.TEXT)), false);
-    private static final ChangeSchema.DataType NONFROZEN_TUPLE_INET_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.TUPLE, Lists.newArrayList(
+    public static final ChangeSchema.DataType NONFROZEN_TUPLE_INET_INT = new ChangeSchema.DataType(ChangeSchema.CqlType.TUPLE, Lists.newArrayList(
             new ChangeSchema.DataType(ChangeSchema.CqlType.INET), new ChangeSchema.DataType(ChangeSchema.CqlType.INT)), false);
 
-    private static final ChangeSchema TEST_SCHEMA_NONFROZEN_COLLECTIONS = new ChangeSchema(Lists.newArrayList(
+    public static final ChangeSchema TEST_SCHEMA_NONFROZEN_COLLECTIONS = new ChangeSchema(Lists.newArrayList(
             new ChangeSchema.ColumnDefinition("cdc$stream_id", 0, new ChangeSchema.DataType(ChangeSchema.CqlType.BLOB), null, null, false),
             new ChangeSchema.ColumnDefinition("cdc$time", 1, new ChangeSchema.DataType(ChangeSchema.CqlType.TIMEUUID), null, null, false),
             new ChangeSchema.ColumnDefinition("cdc$batch_seq_no", 2, new ChangeSchema.DataType(ChangeSchema.CqlType.INT), null, null, false),

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/MockRawChange.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/MockRawChange.java
@@ -1,20 +1,157 @@
 package com.scylladb.cdc.model.worker;
 
+import com.google.common.base.Preconditions;
+import com.google.common.io.BaseEncoding;
 import com.scylladb.cdc.model.worker.cql.Cell;
 import com.scylladb.cdc.model.worker.cql.Field;
 
 import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 public class MockRawChange implements RawChange {
     private final ChangeSchema changeSchema;
     private final Map<String, Object> columnValues;
 
     public MockRawChange(ChangeSchema changeSchema, Map<String, Object> columnValues) {
-        this.changeSchema = changeSchema;
-        this.columnValues = columnValues;
+        this.changeSchema = Preconditions.checkNotNull(changeSchema);
+        this.columnValues = Preconditions.checkNotNull(columnValues);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+        private ChangeSchema changeSchema;
+        private final Map<String, Object> columnValues = new HashMap<String, Object>() {{
+            put("cdc$batch_seq_no", 0);
+            put("cdc$end_of_batch", true);
+        }};
+
+        public Builder withChangeSchema(ChangeSchema changeSchema) {
+            this.changeSchema = changeSchema;
+            return this;
+        }
+
+        public Builder withStreamId(ByteBuffer streamId) {
+            this.columnValues.put("cdc$stream_id", streamId);
+            return this;
+        }
+
+        public Builder withStreamId(String streamId) {
+            byte[] parsedBytes = BaseEncoding.base16().decode(streamId.replace("0x", "").toUpperCase());
+            return withStreamId(ByteBuffer.wrap(parsedBytes));
+        }
+
+        public Builder withTime(UUID timeuuid) {
+            this.columnValues.put("cdc$time", timeuuid);
+            return this;
+        }
+
+        public Builder withTime(String timeuuid) {
+            return withTime(UUID.fromString(timeuuid));
+        }
+
+        public Builder withOperation(byte operation) {
+            this.columnValues.put("cdc$operation", operation);
+            return this;
+        }
+
+        public Builder withOperation(RawChange.OperationType operation) {
+            return withOperation(operation.operationId);
+        }
+
+        public Builder withBatchSequenceNumber(int batchSequenceNumber) {
+            this.columnValues.put("cdc$batch_seq_no", batchSequenceNumber);
+            return this;
+        }
+
+        public Builder withEndOfBatch(boolean isEndOfBatch) {
+            this.columnValues.put("cdc$end_of_batch", isEndOfBatch);
+            return this;
+        }
+
+        public Builder withTTL(long ttl) {
+            this.columnValues.put("cdc$ttl", ttl);
+            return this;
+        }
+
+        public Builder addPrimaryKey(String columnName, Object value) {
+            this.columnValues.put(columnName, value);
+            return this;
+        }
+
+        public Builder addAtomicRegularColumn(String columnName, Object value) {
+            this.columnValues.put(columnName, value);
+            if (value == null) {
+                this.columnValues.put("cdc$deleted_" + columnName, true);
+            }
+            return this;
+        }
+
+        private Field makeField(Object value, ChangeSchema.DataType type) {
+            return new Field() {
+                @Override
+                public Object getAsObject() {
+                    return value;
+                }
+
+                @Override
+                public ChangeSchema.DataType getDataType() {
+                    return type;
+                }
+            };
+        }
+
+        public Builder addFrozenSetRegularColumn(String columnName, Set<Object> set, ChangeSchema.DataType setDataType) {
+            Set<Field> transformedSet = null;
+            if (set != null) {
+                transformedSet = set.stream().map(e -> makeField(e, setDataType)).collect(Collectors.toSet());
+            }
+            return addAtomicRegularColumn(columnName, transformedSet);
+        }
+
+        public Builder addFrozenListRegularColumn(String columnName, List<Object> list, ChangeSchema.DataType listDataType) {
+            List<Field> transformedList = null;
+            if (list != null) {
+                transformedList = list.stream().map(e -> makeField(e, listDataType)).collect(Collectors.toList());
+            }
+            return addAtomicRegularColumn(columnName, transformedList);
+        }
+
+        public Builder addNonfrozenSetRegularColumnOverwrite(String columnName, Set<Object> set, ChangeSchema.DataType setDataType) {
+            Set<Field> transformedSet = null;
+            if (set != null) {
+                transformedSet = set.stream().map(e -> makeField(e, setDataType)).collect(Collectors.toSet());
+            }
+
+            this.columnValues.put(columnName, transformedSet);
+            this.columnValues.put("cdc$deleted_" + columnName, true);
+            // cdc$deleted_elements_ is not set.
+            return this;
+        }
+
+        public Builder addNonfrozenListRegularColumnOverwrite(String columnName, List<Object> list, ChangeSchema.DataType listDataType) {
+            List<Field> transformedList = null;
+            if (list != null) {
+                transformedList = list.stream().map(e -> makeField(e, listDataType)).collect(Collectors.toList());
+            }
+
+            this.columnValues.put(columnName, transformedList);
+            this.columnValues.put("cdc$deleted_" + columnName, true);
+            // cdc$deleted_elements_ is not set.
+            return this;
+        }
+
+        public MockRawChange build() {
+            return new MockRawChange(changeSchema, columnValues);
+        }
     }
 
     @Override

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/RawChangeTest.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/RawChangeTest.java
@@ -1,0 +1,92 @@
+package com.scylladb.cdc.model.worker;
+
+import com.google.common.collect.Sets;
+import org.junit.jupiter.api.Test;
+
+import static com.scylladb.cdc.model.worker.ChangeSchemaTest.*;
+import static com.scylladb.cdc.model.worker.RawChange.OperationType.ROW_INSERT;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class RawChangeTest {
+    @Test
+    public void testIsDeleted() {
+        // INSERT INTO ks.simple(pk, ck, v) VALUES (1, 2, 3);
+        MockRawChange insert1 = MockRawChange.builder()
+                .withChangeSchema(TEST_SCHEMA_SIMPLE)
+                .withStreamId("0xc73400000000000058fe971e700004f1")
+                .withTime("fc7ee7b6-af35-11eb-0443-36839c176f26")
+                .withOperation(ROW_INSERT)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 2)
+                .addAtomicRegularColumn("v", 3)
+                .build();
+
+        assertFalse(insert1.isDeleted("v"));
+        assertThrows(IllegalArgumentException.class, () -> insert1.isDeleted("pk"));
+        assertThrows(IllegalStateException.class, () -> insert1.isDeleted("cdc$operation"));
+
+        // INSERT INTO ks.simple(pk, ck, v) VALUES (1, 2, NULL);
+        MockRawChange insert2 = MockRawChange.builder()
+                .withChangeSchema(TEST_SCHEMA_SIMPLE)
+                .withStreamId("0xc73400000000000058fe971e700004f1")
+                .withTime("d2b8ea72-af39-11eb-aaf9-4e300aa0a9a0")
+                .withOperation(ROW_INSERT)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 2)
+                .addAtomicRegularColumn("v", null)
+                .build();
+
+        assertTrue(insert2.isDeleted("v"));
+
+        // INSERT INTO ks.simple(pk, ck) VALUES (1, 2);
+        MockRawChange insert3 = MockRawChange.builder()
+                .withChangeSchema(TEST_SCHEMA_SIMPLE)
+                .withStreamId("0xc73400000000000058fe971e700004f1")
+                .withTime("098d1744-af3a-11eb-c6af-998af699dbeb")
+                .withOperation(ROW_INSERT)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 2)
+                .build();
+
+        ChangeSchema.ColumnDefinition vColumnDefinition = insert3.getSchema().getColumnDefinition("v");
+        assertFalse(insert3.isDeleted(vColumnDefinition));
+        assertTrue(insert3.isNull("v"));
+
+        // INSERT INTO ks.frozen_collections(pk, ck, v, v2) VALUES (1, 2, {3, 5}, null);
+        MockRawChange insert4 = MockRawChange.builder()
+                .withChangeSchema(TEST_SCHEMA_FROZEN_COLLECTIONS)
+                .withStreamId("0xc73400000000000058fe971e700004f1")
+                .withTime("9989568c-af3a-11eb-e1eb-533f0734bcd9")
+                .withOperation(ROW_INSERT)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 2)
+                .addFrozenSetRegularColumn("v", Sets.newHashSet(3, 5), new ChangeSchema.DataType(ChangeSchema.CqlType.INT))
+                .addFrozenSetRegularColumn("v2", null, new ChangeSchema.DataType(ChangeSchema.CqlType.INT))
+                .build();
+
+        assertFalse(insert4.isDeleted("v"));
+        assertTrue(insert4.isDeleted("v2"));
+        // Not affected columns:
+        assertFalse(insert4.isDeleted("v3"));
+        assertFalse(insert4.isDeleted("v4"));
+
+        // INSERT INTO ks.nonfrozen_collections(pk, ck, v, v2) VALUES (1, 2, {3, 5}, null);
+        MockRawChange insert5 = MockRawChange.builder()
+                .withChangeSchema(TEST_SCHEMA_NONFROZEN_COLLECTIONS)
+                .withStreamId("0xc73400000000000058fe971e700004f1")
+                .withTime("0df7f766-af3c-11eb-0ec0-cad5080ba1d6")
+                .withOperation(ROW_INSERT)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 2)
+                .addNonfrozenSetRegularColumnOverwrite("v", Sets.newHashSet(3, 5), new ChangeSchema.DataType(ChangeSchema.CqlType.INT))
+                .addNonfrozenListRegularColumnOverwrite("v2", null, new ChangeSchema.DataType(ChangeSchema.CqlType.INT))
+                .build();
+
+        // v, v2 are deleted because those are non-frozen collection overwrites
+        assertTrue(insert5.isDeleted("v"));
+        assertTrue(insert5.isDeleted("v2"));
+        // Not affected columns:
+        assertFalse(insert5.isDeleted("v3"));
+        assertFalse(insert5.isDeleted("v4"));
+    }
+}


### PR DESCRIPTION
Fix implementation of `RawChange::isDeleted()`. 

All columns, including: atomic columns, frozen collections, non-frozen collections all have a `cdc$deleted_` column. The only exception to this rule are the partition/clustering keys. The previous implementation of `isDeleted` wrongly assumed that atomic
cells don't have a `cdc$deleted_` column.

After the fix:
1. Add a JavaDoc for `isDeleted`.
2. Add unit tests of `isDeleted`. It required a bit larger change to the code structure, including writing a `MockRawChange` builder.
