### PR TITLE
Remove other Cell getters from Cell

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/cql/Cell.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/cql/Cell.java
@@ -7,12 +7,6 @@ import com.scylladb.cdc.model.worker.ChangeSchema;
 
 public interface Cell extends Field {
     ChangeSchema.ColumnDefinition getColumnDefinition();
-
-    Set<Field> getDeletedElements();
-
-    boolean hasDeletedElements();
-
-    boolean isDeleted();
     
     /**
      * Returns the value of a binary representation of this cell as a <code>ByteBuffer</code>.

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/MockRawChange.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/MockRawChange.java
@@ -12,6 +12,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.LinkedHashSet;
+import java.util.Collections;
 import java.util.stream.Collectors;
 
 public class MockRawChange implements RawChange {
@@ -107,6 +109,22 @@ public class MockRawChange implements RawChange {
                     return type;
                 }
             };
+        }
+
+        private Set<Field> boxObjectsToFields(Set<Object> set, ChangeSchema.DataType setDataType) {
+            if (set == null) {
+                return null;
+            }
+            // Using LinkedHashSet to preserve the order.
+            return set.stream().map(e -> makeField(e, setDataType))
+                    .collect(Collectors.toCollection(LinkedHashSet::new));
+        }
+
+        private List<Field> boxObjectsToFields(List<Object> list, ChangeSchema.DataType listDataType) {
+            if (list == null) {
+                return null;
+            }
+            return list.stream().map(e -> makeField(e, listDataType)).collect(Collectors.toList());
         }
 
         public Builder addFrozenSetRegularColumn(String columnName, Set<Object> set, ChangeSchema.DataType setDataType) {

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/MockRawChange.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/MockRawChange.java
@@ -149,6 +149,12 @@ public class MockRawChange implements RawChange {
             return this;
         }
 
+        public Builder addNonfrozenSetRegularColumnDelete(String columnName, Set<Object> deletedElements, ChangeSchema.DataType setDataType) {
+            Preconditions.checkNotNull(deletedElements);
+            this.columnValues.put("cdc$deleted_elements_" + columnName, boxObjectsToFields(deletedElements, setDataType));
+            return this;
+        }
+
         public MockRawChange build() {
             return new MockRawChange(changeSchema, columnValues);
         }

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/MockRawChange.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/MockRawChange.java
@@ -128,40 +128,22 @@ public class MockRawChange implements RawChange {
         }
 
         public Builder addFrozenSetRegularColumn(String columnName, Set<Object> set, ChangeSchema.DataType setDataType) {
-            Set<Field> transformedSet = null;
-            if (set != null) {
-                transformedSet = set.stream().map(e -> makeField(e, setDataType)).collect(Collectors.toSet());
-            }
-            return addAtomicRegularColumn(columnName, transformedSet);
+            return addAtomicRegularColumn(columnName, boxObjectsToFields(set, setDataType));
         }
 
         public Builder addFrozenListRegularColumn(String columnName, List<Object> list, ChangeSchema.DataType listDataType) {
-            List<Field> transformedList = null;
-            if (list != null) {
-                transformedList = list.stream().map(e -> makeField(e, listDataType)).collect(Collectors.toList());
-            }
-            return addAtomicRegularColumn(columnName, transformedList);
+            return addAtomicRegularColumn(columnName, boxObjectsToFields(list, listDataType));
         }
 
         public Builder addNonfrozenSetRegularColumnOverwrite(String columnName, Set<Object> set, ChangeSchema.DataType setDataType) {
-            Set<Field> transformedSet = null;
-            if (set != null) {
-                transformedSet = set.stream().map(e -> makeField(e, setDataType)).collect(Collectors.toSet());
-            }
-
-            this.columnValues.put(columnName, transformedSet);
+            this.columnValues.put(columnName, boxObjectsToFields(set, setDataType));
             this.columnValues.put("cdc$deleted_" + columnName, true);
             // cdc$deleted_elements_ is not set.
             return this;
         }
 
         public Builder addNonfrozenListRegularColumnOverwrite(String columnName, List<Object> list, ChangeSchema.DataType listDataType) {
-            List<Field> transformedList = null;
-            if (list != null) {
-                transformedList = list.stream().map(e -> makeField(e, listDataType)).collect(Collectors.toList());
-            }
-
-            this.columnValues.put(columnName, transformedList);
+            this.columnValues.put(columnName, boxObjectsToFields(list, listDataType));
             this.columnValues.put("cdc$deleted_" + columnName, true);
             // cdc$deleted_elements_ is not set.
             return this;

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/MockRawChange.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/MockRawChange.java
@@ -173,21 +173,6 @@ public class MockRawChange implements RawChange {
             }
 
             @Override
-            public Set<Field> getDeletedElements() {
-                throw new UnsupportedOperationException("Not implemented yet");
-            }
-
-            @Override
-            public boolean hasDeletedElements() {
-                throw new UnsupportedOperationException("Not implemented yet");
-            }
-
-            @Override
-            public boolean isDeleted() {
-                throw new UnsupportedOperationException("Not implemented yet");
-            }
-
-            @Override
             public ByteBuffer getAsUnsafeBytes() {
                 throw new UnsupportedOperationException("Not implemented yet");
             }

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/RawChangeTest.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/RawChangeTest.java
@@ -1,10 +1,16 @@
 package com.scylladb.cdc.model.worker;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.scylladb.cdc.model.worker.cql.Field;
 import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.Iterator;
 
 import static com.scylladb.cdc.model.worker.ChangeSchemaTest.*;
 import static com.scylladb.cdc.model.worker.RawChange.OperationType.ROW_INSERT;
+import static com.scylladb.cdc.model.worker.RawChange.OperationType.ROW_UPDATE;
 import static org.junit.jupiter.api.Assertions.*;
 
 public class RawChangeTest {
@@ -88,5 +94,65 @@ public class RawChangeTest {
         // Not affected columns:
         assertFalse(insert5.isDeleted("v3"));
         assertFalse(insert5.isDeleted("v4"));
+    }
+
+    @Test
+    public void testGetDeletedElements() {
+        // INSERT INTO ks.simple(pk, ck, v) VALUES (1, 2, 3);
+        MockRawChange insert1 = MockRawChange.builder()
+                .withChangeSchema(TEST_SCHEMA_SIMPLE)
+                .withStreamId("0xc73400000000000058fe971e700004f1")
+                .withTime("fc7ee7b6-af35-11eb-0443-36839c176f26")
+                .withOperation(ROW_INSERT)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 2)
+                .addAtomicRegularColumn("v", 3)
+                .build();
+
+        // v is not a nonfrozen collection, so it doesn't have
+        // a cdc$deleted_elements_ column.
+        assertThrows(IllegalStateException.class, () -> insert1.getDeletedElements("v"));
+
+        // INSERT INTO ks.nonfrozen_collections(pk, ck, v, v2) VALUES (1, 2, {3, 5}, null);
+        MockRawChange insert2 = MockRawChange.builder()
+                .withChangeSchema(TEST_SCHEMA_NONFROZEN_COLLECTIONS)
+                .withStreamId("0xc73400000000000058fe971e700004f1")
+                .withTime("0df7f766-af3c-11eb-0ec0-cad5080ba1d6")
+                .withOperation(ROW_INSERT)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 2)
+                .addNonfrozenSetRegularColumnOverwrite("v", Sets.newHashSet(3, 5), new ChangeSchema.DataType(ChangeSchema.CqlType.INT))
+                .addNonfrozenListRegularColumnOverwrite("v2", null, new ChangeSchema.DataType(ChangeSchema.CqlType.INT))
+                .build();
+
+        // This INSERT only overwrites the column values, so
+        // we expect the cdc$deleted_elements_ to be empty.
+        ChangeSchema.ColumnDefinition colV = insert2.getSchema().getColumnDefinition("v");
+        assertEquals(Collections.emptySet(), insert2.getDeletedElements(colV));
+        assertEquals(Collections.emptySet(), insert2.getDeletedElements("v2"));
+
+        // UPDATE ks.nonfrozen_collections SET v = v - {3, 4} WHERE pk = 1 AND ck = 1;
+        MockRawChange update = MockRawChange.builder()
+                .withChangeSchema(TEST_SCHEMA_NONFROZEN_COLLECTIONS)
+                .withStreamId("0xc417fed9f65a8577e5ac04d700000411")
+                .withTime("ba188a00-b249-11eb-f06a-3815701ff8c4")
+                .withOperation(ROW_UPDATE)
+                .addPrimaryKey("pk", 1)
+                .addPrimaryKey("ck", 1)
+                .addNonfrozenSetRegularColumnDelete("v", Sets.newLinkedHashSet(Lists.newArrayList(3, 4)), new ChangeSchema.DataType(ChangeSchema.CqlType.INT))
+                .build();
+
+        // There should be a cdc$deleted_elements_ column with two
+        // values: 3, 4.
+        assertEquals(2, update.getDeletedElements("v").size());
+
+        Iterator<Field> deletedElements = update.getDeletedElements("v").iterator();
+        Field firstDeletedElement = deletedElements.next();
+        assertEquals(ChangeSchema.CqlType.INT, firstDeletedElement.getDataType().getCqlType());
+        assertEquals(3, firstDeletedElement.getInt());
+
+        Field secondDeletedElement = deletedElements.next();
+        assertEquals(ChangeSchema.CqlType.INT, secondDeletedElement.getDataType().getCqlType());
+        assertEquals(4, secondDeletedElement.getInt());
     }
 }

--- a/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Cell.java
+++ b/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Cell.java
@@ -31,28 +31,6 @@ class Driver3Cell implements Cell {
         return columnDefinition.getCdcLogDataType();
     }
 
-    @SuppressWarnings("unchecked")
-    @Override
-    public Set<Field> getDeletedElements() {
-        if (!hasDeletedElements()) {
-            return null;
-        }
-        return (Set<Field>) change.getAsObject(columnDefinition.getDeletedElementsColumn(change.getSchema()));
-    }
-
-    @Override
-    public boolean hasDeletedElements() {
-        if (!columnDefinition.getBaseTableDataType().isAtomic()) {
-            return false;
-        }
-        return !change.isNull(columnDefinition.getDeletedElementsColumn(change.getSchema()));
-    }
-
-    @Override
-    public boolean isDeleted() {
-        return change.isDeleted(columnDefinition);
-    }
-
     @Override
     public ByteBuffer getAsUnsafeBytes() {
         return change.getAsUnsafeBytes(columnDefinition);


### PR DESCRIPTION
Remove getters that return other `Cell`s from a `Cell`. An example of such getters is `getDeletedElements()`, which for a non-frozen collection `Cell` returned a corresponding `cdc$deleted_elements` value. The main reason is design-wise: `Cell` describes only a single `Cell`, not other cells (columns). The logic to fetch other `Cell`s should be in `RawChange`.

Those getters provided a hope of easier parsing of Scylla CDC changes. But adding those getters is only "1%" of effort required to properly parse non-frozen collection mutations. The logic required to do so is much larger and in no way addressed by those getters. However, my planned higher-level API provides a much more comprehensive way to consume non-frozen collection changes.

"Sprinkling" getters around the codebase might seem like a good idea, for example: `cell.getDataType()` vs `cell.getColumnDefinition().getCdcLogDataType()` seems like an improvement, but a side-effect of such patchwork design is that a structure of API is lost - you can get the same information in N ways, so if you want to access some property where should you go? Such getters remove the "hierarchical" design of the API.

Removed:
- `getDeletedElements()`
- `hasDeletedElements()`
- `isDeleted()`

`isDeleted()` was already accessible by `change.isDeleted("column name")`. For `getDeletedElements` a new getter is introduced in `RawChange`: `RawChange::getDeletedElements(String columnName)`. `hasDeletedElements` is not addressed in this PR.

I added unit tests for the added `getDeletedElements` method. I performed a minor cleanup in `MockRawChange` (to implement a new `addNonfrozenSetRegularColumnDelete` method)  and fixed `MockRawChange::getAsObject` (return empty collections instead of `null`).