### PR TITLE
Move other column getters from ChangeSchema

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/ChangeSchema.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/ChangeSchema.java
@@ -249,24 +249,6 @@ public class ChangeSchema {
             return baseTableColumnType;
         }
 
-        public ColumnDefinition getDeletedColumn(ChangeSchema schema) {
-            if (baseTableDataType == null) {
-                throw new IllegalStateException("Cannot get deleted elements column for CDC columns.");
-            }
-            return schema.getColumnDefinition("cdc$deleted_" + columnName);
-        }
-
-        public ColumnDefinition getDeletedElementsColumn(ChangeSchema schema) {
-            if (baseTableDataType == null) {
-                throw new IllegalStateException("Cannot get deleted elements column for CDC columns.");
-            }
-            if (baseTableDataType.isAtomic()) {
-                throw new IllegalStateException(
-                        "Cannot get deleted elements column for frozen or non-collection columns.");
-            }
-            return schema.getColumnDefinition("cdc$deleted_elements_" + columnName);
-        }
-
         @Override
         public int hashCode() {
             return Objects.hash(baseTableColumnType, baseTableDataType, cdcLogDataType, columnName, index);
@@ -317,6 +299,88 @@ public class ChangeSchema {
         // TODO - do not linearly search
         Optional<ColumnDefinition> result = columnDefinitions.stream().filter(c -> c.getColumnName().equals(columnName)).findFirst();
         return result.orElseThrow(() -> new IllegalArgumentException("Column name " + columnName + " is not present in change schema."));
+    }
+
+    /**
+     * Returns the column definition of the deleted column for the provided
+     * column name.
+     * <p>
+     * This method returns the column definition of the <code>cdc$deleted_</code>
+     * column for the given column name. It is only relevant for the regular columns
+     * (columns not in a primary key) of the base table, because only
+     * those columns have a corresponding deleted column. See
+     * <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-basic-operations/">Basic operations in CDC</a> page for
+     * more details.
+     *
+     * @param columnName the column name for which to retrieve the deleted column definition.
+     * @return the column definition of the deleted column for the given column name.
+     * @see RawChange#isDeleted(String)
+     * @see <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-basic-operations/">Basic operations in CDC</a>
+     */
+    public ColumnDefinition getDeletedColumnDefinition(String columnName) {
+        return getColumnDefinition("cdc$deleted_" + columnName);
+    }
+
+    /**
+     * Returns the column definition of the deleted column for the provided
+     * column definition.
+     * <p>
+     * This method returns the column definition of the <code>cdc$deleted_</code>
+     * column for the given column definition. It is only relevant for the regular columns
+     * (columns not in a primary key) of the base table, because only
+     * those columns have a corresponding deleted column. See
+     * <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-basic-operations/">Basic operations in CDC</a> page for
+     * more details.
+     *
+     * @param columnDefinition the column definition for which to retrieve the deleted column definition.
+     * @return the column definition of the deleted column for the given column definition.
+     * @see RawChange#isDeleted(ColumnDefinition)
+     * @see <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-basic-operations/">Basic operations in CDC</a>
+     */
+    public ColumnDefinition getDeletedColumnDefinition(ColumnDefinition columnDefinition) {
+        return getDeletedColumnDefinition(columnDefinition.getColumnName());
+    }
+
+    /**
+     * Returns the column definition of the deleted elements column for the provided
+     * column name.
+     * <p>
+     * This method returns the column definition of the <code>cdc$deleted_elements_</code>
+     * column for the given column name. It is only relevant for the regular columns
+     * (columns not in a primary key) of the base table with a non-frozen collection
+     * type (for example {@code SET<INT>}). Other columns don't have a
+     * corresponding deleted elements column. See
+     * <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-advanced-types/">Advanced column types</a> page for
+     * more details.
+     *
+     * @param columnName the column name for which to retrieve the deleted elements column definition.
+     * @return the column definition of the deleted elements column for the given column name.
+     * @see RawChange#getDeletedElements(String)
+     * @see <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-advanced-types/">Advanced column types</a>
+     */
+    public ColumnDefinition getDeletedElementsColumnDefinition(String columnName) {
+        return getColumnDefinition("cdc$deleted_elements_" + columnName);
+    }
+
+    /**
+     * Returns the column definition of the deleted elements column for the provided
+     * column definition.
+     * <p>
+     * This method returns the column definition of the <code>cdc$deleted_elements_</code>
+     * column for the given column definition. It is only relevant for the regular columns
+     * (columns not in a primary key) of the base table with a non-frozen collection
+     * type (for example {@code SET<INT>}). Other columns don't have a
+     * corresponding deleted elements column. See
+     * <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-advanced-types/">Advanced column types</a> page for
+     * more details.
+     *
+     * @param columnDefinition the column definition for which to retrieve the deleted elements column definition.
+     * @return the column definition of the deleted elements column for the given column definition.
+     * @see RawChange#getDeletedElements(ColumnDefinition)
+     * @see <a href="https://docs.scylladb.com/using-scylla/cdc/cdc-advanced-types/">Advanced column types</a>
+     */
+    public ColumnDefinition getDeletedElementsColumnDefinition(ColumnDefinition columnDefinition) {
+        return getDeletedElementsColumnDefinition(columnDefinition.getColumnName());
     }
 
     // TODO - add getTableName() here.

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/RawChange.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/RawChange.java
@@ -175,7 +175,9 @@ public interface RawChange extends Iterable<Cell> {
      * @return the boolean value of the deleted column for the given column.
      */
     default boolean isDeleted(ChangeSchema.ColumnDefinition columnDefinition) {
-        Boolean value = getCell(columnDefinition.getDeletedColumn(getSchema())).getBoolean();
+        ChangeSchema.ColumnDefinition deletedColumnDefinition =
+                getSchema().getDeletedColumnDefinition(columnDefinition);
+        Boolean value = getCell(deletedColumnDefinition).getBoolean();
         return value != null && value;
     }
 
@@ -230,7 +232,8 @@ public interface RawChange extends Iterable<Cell> {
      *         set.
      */
     default Set<Field> getDeletedElements(ChangeSchema.ColumnDefinition columnDefinition) {
-        ChangeSchema.ColumnDefinition deletedElementsColumnDefinition = columnDefinition.getDeletedElementsColumn(getSchema());
+        ChangeSchema.ColumnDefinition deletedElementsColumnDefinition =
+                getSchema().getDeletedElementsColumnDefinition(columnDefinition);
         return getCell(deletedElementsColumnDefinition).getSet();
     }
 

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/RawChangeTest.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/model/worker/RawChangeTest.java
@@ -29,7 +29,7 @@ public class RawChangeTest {
 
         assertFalse(insert1.isDeleted("v"));
         assertThrows(IllegalArgumentException.class, () -> insert1.isDeleted("pk"));
-        assertThrows(IllegalStateException.class, () -> insert1.isDeleted("cdc$operation"));
+        assertThrows(IllegalArgumentException.class, () -> insert1.isDeleted("cdc$operation"));
 
         // INSERT INTO ks.simple(pk, ck, v) VALUES (1, 2, NULL);
         MockRawChange insert2 = MockRawChange.builder()
@@ -111,7 +111,7 @@ public class RawChangeTest {
 
         // v is not a nonfrozen collection, so it doesn't have
         // a cdc$deleted_elements_ column.
-        assertThrows(IllegalStateException.class, () -> insert1.getDeletedElements("v"));
+        assertThrows(IllegalArgumentException.class, () -> insert1.getDeletedElements("v"));
 
         // INSERT INTO ks.nonfrozen_collections(pk, ck, v, v2) VALUES (1, 2, {3, 5}, null);
         MockRawChange insert2 = MockRawChange.builder()


### PR DESCRIPTION
Delete getters that return other column definitions from a `ColumnDefinition`. The previous API required you to pass `ChangeSchema` object ("parent" object) to the `ChangeSchema.ColumnDefinition` object ("child" object). Due to this design, it was quite cumbersome:

```
rawChange.getSchema().getColumnDefinition("mycell").getDeletedColumn(rawChange.getSchema())
```

A `ColumnDefinition` class should not know anything about any other columns. The responsibility should be in `ChangeSchema`, which manages multiple columns.

Therefore, `getDeletedColumn` and `getDeletedElementsColumn` are moved out to `ChangeSchema`. The example above now looks like this:

```
rawChange.getSchema().getDeletedColumnDefinition("mycell")
```

Add JavaDoc and tests for new methods.