### PR TITLE
Add configurable consistency level and local DC

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/CQLConfiguration.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/CQLConfiguration.java
@@ -9,13 +9,64 @@ import java.util.List;
 
 public class CQLConfiguration {
     private static final int DEFAULT_PORT = 9042;
+    private static final ConsistencyLevel DEFAULT_CONSISTENCY_LEVEL = ConsistencyLevel.QUORUM;
+
+    /**
+     * The consistency level of read queries to Scylla.
+     */
+    public enum ConsistencyLevel {
+        /**
+         * Waits for a response from single replica
+         * in the local data center.
+         */
+        LOCAL_ONE,
+        /**
+         * Waits for a response from single replica.
+         */
+        ONE,
+        /**
+         * Waits for responses from two replicas.
+         */
+        TWO,
+        /**
+         * Waits for responses from three replicas.
+         */
+        THREE,
+        /**
+         * Waits for responses from a quorum of replicas
+         * in the same DC as the coordinator.
+         * <p>
+         * Local quorum is defined as:
+         * <code>dataCenterReplicationFactor / 2 + 1</code>,
+         * where <code>dataCenterReplicationFactor</code> is the
+         * configured replication factor for the datacenter of
+         * the coordinator node.
+         */
+        LOCAL_QUORUM,
+        /**
+         * Waits for responses from a quorum of replicas.
+         * <p>
+         * Quorum is defined as:
+         * <code>(dc1ReplicationFactor + dc2ReplicationFactor + ...) / 2 + 1</code>,
+         * where <code>dc1ReplicationFactor</code>, <code>dc2ReplicationFactor</code>, ... are the configured
+         * replication factors for all data centers.
+         */
+        QUORUM,
+        /**
+         * Waits for responses from all replicas.
+         */
+        ALL
+    }
 
     public final List<InetSocketAddress> contactPoints;
     public final String user;
     public final String password;
+    private final ConsistencyLevel consistencyLevel;
+    private final String localDCName;
 
     private CQLConfiguration(List<InetSocketAddress> contactPoints,
-                            String user, String password) {
+                            String user, String password, ConsistencyLevel consistencyLevel,
+                            String localDCName) {
         this.contactPoints = Preconditions.checkNotNull(contactPoints);
         Preconditions.checkArgument(!contactPoints.isEmpty());
 
@@ -25,6 +76,38 @@ public class CQLConfiguration {
         // or provided user-password pair.
         Preconditions.checkArgument((this.user == null && this.password == null)
                 || (this.user != null && this.password != null));
+
+        this.consistencyLevel = Preconditions.checkNotNull(consistencyLevel);
+        this.localDCName = localDCName;
+    }
+
+    /**
+     * Returns the configured consistency level.
+     * <p>
+     * This consistency level is used in read queries to the
+     * CDC log table. The queries to system tables, such
+     * as <code>system_distributed.cdc_streams_descriptions_v2</code> do
+     * not respect this configuration option.
+     *
+     * @return configured consistency level.
+     */
+    public ConsistencyLevel getConsistencyLevel() {
+        return consistencyLevel;
+    }
+
+    /**
+     * Returns the name of the configured local datacenter.
+     * <p>
+     * This local datacenter name will be used to setup
+     * the connection to Scylla to prioritize sending requests to
+     * the nodes in the local datacenter. If this parameter
+     * was not configured, this method returns <code>null</code>.
+     *
+     * @return the name of configured local datacenter or
+     *         <code>null</code> if it was not configured.
+     */
+    public String getLocalDCName() {
+        return localDCName;
     }
 
     public static Builder builder() {
@@ -35,6 +118,8 @@ public class CQLConfiguration {
         private final List<InetSocketAddress> contactPoints = new ArrayList<>();
         private String user = null;
         private String password = null;
+        private ConsistencyLevel consistencyLevel = DEFAULT_CONSISTENCY_LEVEL;
+        private String localDCName = null;
 
         public Builder addContactPoint(InetSocketAddress contactPoint) {
             Preconditions.checkNotNull(contactPoint);
@@ -65,8 +150,39 @@ public class CQLConfiguration {
             return this;
         }
 
+        /**
+         * Sets the consistency level of CDC table read queries.
+         * <p>
+         * This consistency level is used only for read queries
+         * to the CDC log table. The queries to system tables, such
+         * as <code>system_distributed.cdc_streams_descriptions_v2</code> do
+         * not respect this configuration option.
+         *
+         * @param consistencyLevel consistency level to set.
+         * @return a reference to this builder.
+         */
+        public Builder withConsistencyLevel(ConsistencyLevel consistencyLevel) {
+            this.consistencyLevel = Preconditions.checkNotNull(consistencyLevel);
+            return this;
+        }
+
+        /**
+         * Sets the name of local datacenter.
+         * <p>
+         * This local datacenter name will be used to setup
+         * the connection to Scylla to prioritize sending requests to
+         * the nodes in the local datacenter.
+         *
+         * @param localDCName the name of local datacenter to set.
+         * @return a reference to this builder.
+         */
+        public Builder withLocalDCName(String localDCName) {
+            this.localDCName = Preconditions.checkNotNull(localDCName);
+            return this;
+        }
+
         public CQLConfiguration build() {
-            return new CQLConfiguration(contactPoints, user, password);
+            return new CQLConfiguration(contactPoints, user, password, consistencyLevel, localDCName);
         }
     }
 }

--- a/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Session.java
+++ b/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Session.java
@@ -1,13 +1,16 @@
 package com.scylladb.cdc.cql.driver3;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.ConsistencyLevel;
 import com.datastax.driver.core.ProtocolVersion;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
 import com.scylladb.cdc.cql.CQLConfiguration;
 
 public class Driver3Session implements AutoCloseable {
     private final Cluster driverCluster;
     private final Session driverSession;
+    private final ConsistencyLevel consistencyLevel;
 
     public Driver3Session(CQLConfiguration cqlConfiguration) {
         Cluster.Builder clusterBuilder = Cluster.builder()
@@ -20,12 +23,47 @@ public class Driver3Session implements AutoCloseable {
             clusterBuilder = clusterBuilder.withCredentials(user, password);
         }
 
+        if (cqlConfiguration.getLocalDCName() != null) {
+            clusterBuilder = clusterBuilder.withLoadBalancingPolicy(
+                    DCAwareRoundRobinPolicy.builder().withLocalDc(cqlConfiguration.getLocalDCName()).build());
+        }
+
         driverCluster = clusterBuilder.build();
         driverSession = driverCluster.connect();
+
+        switch (cqlConfiguration.getConsistencyLevel()) {
+            case ONE:
+                consistencyLevel = ConsistencyLevel.ONE;
+                break;
+            case TWO:
+                consistencyLevel = ConsistencyLevel.TWO;
+                break;
+            case THREE:
+                consistencyLevel = ConsistencyLevel.THREE;
+                break;
+            case QUORUM:
+                consistencyLevel = ConsistencyLevel.QUORUM;
+                break;
+            case ALL:
+                consistencyLevel = ConsistencyLevel.ALL;
+                break;
+            case LOCAL_QUORUM:
+                consistencyLevel = ConsistencyLevel.LOCAL_QUORUM;
+                break;
+            case LOCAL_ONE:
+                consistencyLevel = ConsistencyLevel.LOCAL_ONE;
+                break;
+            default:
+                throw new IllegalStateException("Unsupported consistency level: " + cqlConfiguration.getConsistencyLevel());
+        }
     }
 
     protected Session getDriverSession() {
         return driverSession;
+    }
+
+    protected ConsistencyLevel getConsistencyLevel() {
+        return consistencyLevel;
     }
 
     @Override


### PR DESCRIPTION
Add an option to configure the consistency level. The configured consistency level is used only for CDC log table queries. By default it is QUORUM.

Add an option to configure the local DC name. By default it is not set, which does not change the prior behavior. If set, the started connection is with DCAwareRoundRobinPolicy with this local DC name.