### PR TITLE
Small improvements to integration tests

### DIFF
--- a/scylla-cdc-driver3/pom.xml
+++ b/scylla-cdc-driver3/pom.xml
@@ -121,6 +121,7 @@
                         <scylla.docker.hostname>${docker.host.address}</scylla.docker.hostname>
                         <scylla.docker.port>${scylla.docker.port}</scylla.docker.port>
                     </systemPropertyVariables>
+                    <trimStackTrace>false</trimStackTrace>
                 </configuration>
 
                 <executions>

--- a/scylla-cdc-driver3/src/test/java/com/scylladb/cdc/cql/driver3/BaseScyllaIntegrationTest.java
+++ b/scylla-cdc-driver3/src/test/java/com/scylladb/cdc/cql/driver3/BaseScyllaIntegrationTest.java
@@ -1,26 +1,43 @@
 package com.scylladb.cdc.cql.driver3;
 
 import com.datastax.driver.core.Cluster;
+import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.schemabuilder.SchemaBuilder;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Sets;
 import com.scylladb.cdc.cql.CQLConfiguration;
+import com.scylladb.cdc.cql.MasterCQL;
+import com.scylladb.cdc.model.*;
+import com.scylladb.cdc.model.worker.Task;
+import com.scylladb.cdc.model.worker.TaskState;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 
 import java.net.InetSocketAddress;
-import java.util.HashMap;
-import java.util.Properties;
+import java.nio.ByteBuffer;
+import java.util.*;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 public class BaseScyllaIntegrationTest {
+    protected static final long SCYLLA_TIMEOUT_MS = 3000;
+
     protected Session driverSession;
     protected Cluster driverCluster;
-    protected Driver3Session librarySession;
+
+    private String hostname;
+    private int port;
+    private Driver3Session librarySession;
 
     @BeforeEach
     public void beforeEach() {
         Properties systemProperties = System.getProperties();
-        String hostname = systemProperties.getProperty("scylla.docker.hostname");
-        int port = Integer.parseInt(systemProperties.getProperty("scylla.docker.port"));
+
+        hostname = Preconditions.checkNotNull(systemProperties.getProperty("scylla.docker.hostname"));
+        port = Integer.parseInt(systemProperties.getProperty("scylla.docker.port"));
 
         driverCluster = Cluster.builder()
                 .addContactPointsWithPorts(new InetSocketAddress(hostname, port))
@@ -36,12 +53,28 @@ public class BaseScyllaIntegrationTest {
                 put("class", "SimpleStrategy");
                 put("replication_factor", "1");
         }}));
+    }
 
-        CQLConfiguration cqlConfiguration = CQLConfiguration.builder()
-                .addContactPoint(hostname, port)
-                .build();
+    /**
+     * Returns a cached {@link Driver3Session} session or builds it.
+     * <p>
+     * The session is only built once per
+     * each test and is cached between different invocations
+     * of this method. The cached session is closed and
+     * removed after each test (in {@link #afterEach()}).
+     *
+     * @return a {@link Driver3Session} session for a test. It is cached
+     *         between this method's invocations.
+     */
+    public Driver3Session buildLibrarySession() {
+        if (librarySession == null) {
+            CQLConfiguration cqlConfiguration = CQLConfiguration.builder()
+                    .addContactPoint(hostname, port)
+                    .build();
+            librarySession = new Driver3Session(cqlConfiguration);
+        }
 
-        librarySession = new Driver3Session(cqlConfiguration);
+        return librarySession;
     }
 
     @AfterEach
@@ -50,12 +83,15 @@ public class BaseScyllaIntegrationTest {
             // Drop the test keyspace.
             driverSession.execute(SchemaBuilder.dropKeyspace("ks").ifExists());
             driverSession.close();
+            driverSession = null;
         }
         if (driverCluster != null) {
             driverCluster.close();
+            driverCluster = null;
         }
         if (librarySession != null) {
             librarySession.close();
+            librarySession = null;
         }
     }
 }

--- a/scylla-cdc-driver3/src/test/java/com/scylladb/cdc/cql/driver3/Driver3MasterCQLIT.java
+++ b/scylla-cdc-driver3/src/test/java/com/scylladb/cdc/cql/driver3/Driver3MasterCQLIT.java
@@ -15,13 +15,11 @@ import java.util.concurrent.TimeoutException;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class Driver3MasterCQLIT extends BaseScyllaIntegrationTest {
-    private static final long SCYLLA_TIMEOUT_MS = 3000;
-
     @Test
     public void testMasterFetchesFirstGenerationId() throws InterruptedException, ExecutionException, TimeoutException {
         // Check that Driver3MasterCQL can fetch the first generation id.
 
-        MasterCQL masterCQL = new Driver3MasterCQL(librarySession);
+        MasterCQL masterCQL = new Driver3MasterCQL(buildLibrarySession());
         Optional<GenerationId> firstGeneration =
                 masterCQL.fetchFirstGenerationId().get(SCYLLA_TIMEOUT_MS, TimeUnit.MILLISECONDS);
 


### PR DESCRIPTION
Small improvements to integration tests:
1. `trimStackTrace=false` so that when the integration test fails, it prints the full stack trace of the failure, not only an exception name.
2. Create a `librarySession` object on-demand. Previously, it was created in a constructor of `BaseScyllaIntegrationTest`, right after a `driverSession` was created. This caused problems: we use the `driverSession` to create new tables. However, `librarySession` is a different instance of session. Upon creating a new table in `driverSession`, a metadata was not immediately refreshed by `librarySession`. A fix to this problem is to create `librarySession` on-demand (for example after `CREATE TABLE` with `driverSession`), so that it will fetch the new metadata (when starting).
3. Add a utility method to `BaseScyllaIntegrationTest`, which fetches a first `RawChange` in a given CDC table.