### PR TITLE
Bump Scylla versions in continuous integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,7 +44,7 @@ jobs:
 
     strategy:
       matrix:
-        scylla-docker-version: ['latest', '4.4.1', '4.3.2']
+        scylla-docker-version: ['latest', '4.4.4', '4.3.6']
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Bump Scylla versions in continuous integration to the latest minor releases in 4.4 and 4.3.