### PR TITLE
Update versions of several dependencies

### DIFF
--- a/scylla-cdc-driver3/pom.xml
+++ b/scylla-cdc-driver3/pom.xml
@@ -13,7 +13,11 @@
     <packaging>jar</packaging>
 
     <properties>
-        <scylla.driver.version>3.10.2-scylla-1</scylla.driver.version>
+        <scylla.driver.version>3.11.2.1</scylla.driver.version>
+
+        <jackson-databind.version>2.13.4.1</jackson-databind.version>
+        <log4j.version>2.17.1</log4j.version>
+        <snakeyaml.version>1.32</snakeyaml.version>
 
         <!-- Integration tests. -->
         <docker.skip>false</docker.skip>
@@ -32,6 +36,16 @@
             <artifactId>scylla-driver-core</artifactId>
             <version>${scylla.driver.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>${jackson-databind.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>${snakeyaml.version}</version>
+        </dependency>
     </dependencies>
 
     <build>
@@ -47,6 +61,16 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
                             <relocations>
                                 <relocation>
                                     <pattern>com.datastax.</pattern>


### PR DESCRIPTION
This is a "backport" of a part of scylladb/scylla-cdc-source-connector#25. Most of the updates in that PR were due to older versions of dependencies in scylla-cdc-java itself.

Main reason for dependency version upgrades is to appease CVE checker tools. This should deal with all critical and high severity level CVEs.