### PR TITLE
Unshade logging dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,20 +32,20 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>com.google.flogger</groupId>
+                <artifactId>flogger</artifactId>
+                <version>${flogger.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.flogger</groupId>
+                <artifactId>flogger-system-backend</artifactId>
+                <version>${flogger.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
     <dependencies>
-        <dependency>
-            <groupId>com.google.flogger</groupId>
-            <artifactId>flogger</artifactId>
-            <version>${flogger.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.flogger</groupId>
-            <artifactId>flogger-system-backend</artifactId>
-            <version>${flogger.version}</version>
-        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>

--- a/scylla-cdc-base/pom.xml
+++ b/scylla-cdc-base/pom.xml
@@ -26,5 +26,13 @@
             <version>4.1.75.Final</version>
             <scope>compile</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.flogger</groupId>
+            <artifactId>flogger</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.flogger</groupId>
+            <artifactId>flogger-system-backend</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/scylla-cdc-driver3/pom.xml
+++ b/scylla-cdc-driver3/pom.xml
@@ -46,6 +46,14 @@
             <artifactId>snakeyaml</artifactId>
             <version>${snakeyaml.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.google.flogger</groupId>
+            <artifactId>flogger</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.flogger</groupId>
+            <artifactId>flogger-system-backend</artifactId>
+        </dependency>
     </dependencies>
 
     <build>
@@ -61,6 +69,12 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
+                            <artifactSet>
+                                <excludes>
+                                    <exclude>com.google.flogger</exclude>
+                                    <exclude>org.slf4j</exclude>
+                                </excludes>
+                            </artifactSet>
                             <filters>
                                 <filter>
                                     <artifact>*:*</artifact>
@@ -83,6 +97,9 @@
                                 <relocation>
                                     <pattern>com.google.</pattern>
                                     <shadedPattern>shaded.com.scylladb.cdc.driver3.</shadedPattern>
+                                    <excludes>
+                                        <exclude>com.google.common.flogger.*</exclude>
+                                    </excludes>
                                 </relocation>
                             </relocations>
                         </configuration>


### PR DESCRIPTION
Excludes flogger and slf4j dependencies from shading process. Slightly modifies dependency structure.
Before the change every submodule inherited changed dependencies from parent. Even if such dependency seemed to be unnecessary in a submodule.