### PR TITLE
Update scylla-driver-core dependency to 3.11.5.0

### DIFF
--- a/scylla-cdc-driver3/pom.xml
+++ b/scylla-cdc-driver3/pom.xml
@@ -13,7 +13,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <scylla.driver.version>3.11.4.0</scylla.driver.version>
+        <scylla.driver.version>3.11.5.0</scylla.driver.version>
 
         <log4j.version>2.17.1</log4j.version>
 

--- a/scylla-cdc-replicator/pom.xml
+++ b/scylla-cdc-replicator/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <scylla.driver.version>3.11.4.0</scylla.driver.version>
+        <scylla.driver.version>3.11.5.0</scylla.driver.version>
 
         <!-- Integration tests. -->
         <docker.skip>false</docker.skip>


### PR DESCRIPTION
Update the scylla-driver-code dependency to just released 3.11.5.0, which updates org.bouncycastle:bcprov-jdk15on dependency.