### PR TITLE
Change task update logic after consumed change

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/TaskAction.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/TaskAction.java
@@ -152,7 +152,12 @@ abstract class TaskAction {
         @Override
         public CompletableFuture<TaskAction> run() {
             if (change.isPresent()) {
-                Task updatedTask = task.updateState(change.get().getId());
+                Task updatedTask;
+                if(change.get().isEndOfBatch()) {
+                    updatedTask = task.updateState(change.get().getId());
+                } else {
+                    updatedTask = task;
+                }
 
                 try {
                     CompletableFuture<TaskAction> taskActionFuture = workerConfiguration.consumer.getConsumerDispatch().consume(task, change.get(), updatedTask)


### PR DESCRIPTION
Currently when consuming each RawChange the task will be updated with its details. This leads to unwanted behaviour when consuming batches with identical StreamId and ChangeTime. From the Consumer point of view, all those changes will have identical ChangeIds. This leads to the situation where if Consumer fails in the middle of the batch, the retry after the delay will skip the rest of the batch as its ChangeId will be considered as already seen.

This commit makes it so that taskState is updated only after consuming end of batch RawChange.