### PR TITLE
Add configurable fetch size

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/CQLConfiguration.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/CQLConfiguration.java
@@ -64,10 +64,11 @@ public class CQLConfiguration {
     private final ConsistencyLevel consistencyLevel;
     private final String localDCName;
     public final SslConfig sslConfig;
+    public final int queryOptionsFetchSize;
 
     private CQLConfiguration(List<InetSocketAddress> contactPoints,
                             String user, String password, ConsistencyLevel consistencyLevel,
-                            String localDCName, SslConfig sslConfig) {
+                            String localDCName, SslConfig sslConfig, int queryOptionsFetchSize) {
         this.contactPoints = Preconditions.checkNotNull(contactPoints);
         Preconditions.checkArgument(!contactPoints.isEmpty());
 
@@ -81,6 +82,7 @@ public class CQLConfiguration {
         this.consistencyLevel = Preconditions.checkNotNull(consistencyLevel);
         this.localDCName = localDCName;
         this.sslConfig = sslConfig;
+        this.queryOptionsFetchSize = queryOptionsFetchSize;
     }
 
     /**
@@ -123,6 +125,7 @@ public class CQLConfiguration {
         private ConsistencyLevel consistencyLevel = DEFAULT_CONSISTENCY_LEVEL;
         private String localDCName = null;
         private SslConfig sslConfig = null;
+        private int queryOptionsFetchSize = 0;
 
         public Builder addContactPoint(InetSocketAddress contactPoint) {
             Preconditions.checkNotNull(contactPoint);
@@ -189,8 +192,19 @@ public class CQLConfiguration {
             return this;
         }
 
+        /**
+         * Sets the default page fetch size for select queries. Will be passed to {@code QueryOptions}
+         * of the driver's {@code Cluster.Builder}. 0 means default to driver's default.
+         * @param fetchSize select query page fetch size.
+         * @return a reference to this builder.
+         */
+        public Builder withQueryOptionsFetchSize(int fetchSize) {
+            this.queryOptionsFetchSize = fetchSize;
+            return this;
+        }
+
         public CQLConfiguration build() {
-            return new CQLConfiguration(contactPoints, user, password, consistencyLevel, localDCName, sslConfig);
+            return new CQLConfiguration(contactPoints, user, password, consistencyLevel, localDCName, sslConfig, queryOptionsFetchSize);
         }
     }
 }

--- a/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Session.java
+++ b/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Session.java
@@ -28,7 +28,6 @@ public class Driver3Session implements AutoCloseable {
     public Driver3Session(CQLConfiguration cqlConfiguration) {
         Cluster.Builder clusterBuilder = Cluster.builder()
                 .withProtocolVersion(ProtocolVersion.NEWEST_SUPPORTED);
-
         clusterBuilder = clusterBuilder.addContactPointsWithPorts(cqlConfiguration.contactPoints);
 
         if (cqlConfiguration.sslConfig != null) {
@@ -107,7 +106,6 @@ public class Driver3Session implements AutoCloseable {
         // and Driver3WorkerCQLIT#testPreparedStatementOldSchemaAfterAlter
         // for more context.
         clusterBuilder = clusterBuilder.withProtocolVersion(ProtocolVersion.V4);
-
         String user = cqlConfiguration.user, password = cqlConfiguration.password;
         if (user != null && password != null) {
             clusterBuilder = clusterBuilder.withCredentials(user, password);
@@ -116,6 +114,12 @@ public class Driver3Session implements AutoCloseable {
         if (cqlConfiguration.getLocalDCName() != null) {
             clusterBuilder = clusterBuilder.withLoadBalancingPolicy(
                     DCAwareRoundRobinPolicy.builder().withLocalDc(cqlConfiguration.getLocalDCName()).build());
+        }
+
+        if (cqlConfiguration.queryOptionsFetchSize > 0) {
+            QueryOptions queryOptions = new QueryOptions();
+            queryOptions.setFetchSize(cqlConfiguration.queryOptionsFetchSize);
+            clusterBuilder = clusterBuilder.withQueryOptions(queryOptions);
         }
 
         driverCluster = clusterBuilder.build();


### PR DESCRIPTION
Adds an option for configurable default fetch size. This option will be used in QueryOptions when creating a driver session.