### PR TITLE
Bug fix

### DIFF
--- a/scylla-cdc-lib/src/main/java/com/scylladb/cdc/lib/CDCConsumer.java
+++ b/scylla-cdc-lib/src/main/java/com/scylladb/cdc/lib/CDCConsumer.java
@@ -198,7 +198,7 @@ public final class CDCConsumer implements AutoCloseable {
         }
 
         public Builder withSleepBeforeGenerationDoneMs(long sleepBeforeGenerationDoneMs) {
-            masterConfigurationBuilder.withSleepBeforeFirstGenerationMs(sleepBeforeGenerationDoneMs);
+            masterConfigurationBuilder.withSleepBeforeGenerationDoneMs(sleepBeforeGenerationDoneMs);
             return this;
         }
 


### PR DESCRIPTION
withSleepBeforeGenerationDoneMs was internally calling withSleepBeforeFirstGenerationMs.
The property for withSleepBeforeFirstGenerationMs was getting overwritten instead of withSleepBeforeGenerationDoneMs.
 Rectified it to withSleepBeforeGenerationDoneMs