### PR TITLE
Make load balancing policy token aware when local-dc is provided

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/CQLConfiguration.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/CQLConfiguration.java
@@ -63,12 +63,13 @@ public class CQLConfiguration {
     public final String password;
     private final ConsistencyLevel consistencyLevel;
     private final String localDCName;
+    private final String localRackName;
     public final SslConfig sslConfig;
     public final int queryOptionsFetchSize;
 
     private CQLConfiguration(List<InetSocketAddress> contactPoints,
                             String user, String password, ConsistencyLevel consistencyLevel,
-                            String localDCName, SslConfig sslConfig, int queryOptionsFetchSize) {
+                            String localDCName, String localRackName, SslConfig sslConfig, int queryOptionsFetchSize) {
         this.contactPoints = Preconditions.checkNotNull(contactPoints);
         Preconditions.checkArgument(!contactPoints.isEmpty());
 
@@ -81,6 +82,7 @@ public class CQLConfiguration {
 
         this.consistencyLevel = Preconditions.checkNotNull(consistencyLevel);
         this.localDCName = localDCName;
+        this.localRackName = localRackName;
         this.sslConfig = sslConfig;
         this.queryOptionsFetchSize = queryOptionsFetchSize;
     }
@@ -114,6 +116,21 @@ public class CQLConfiguration {
         return localDCName;
     }
 
+    /**
+     * Returns the name of the configured local rack.
+     * <p>
+     * This local rack name will be used to setup
+     * the connection to Scylla to prioritize sending requests to
+     * the nodes in the local rack (in the local datacenter). If this parameter
+     * was not configured, this method returns <code>null</code>.
+     *
+     * @return the name of configured local rack or
+     * <code>null</code> if it was not configured.
+     */
+    public String getLocalRackName() {
+        return localRackName;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -124,6 +141,7 @@ public class CQLConfiguration {
         private String password = null;
         private ConsistencyLevel consistencyLevel = DEFAULT_CONSISTENCY_LEVEL;
         private String localDCName = null;
+        private String localRackName = null;
         private SslConfig sslConfig = null;
         private int queryOptionsFetchSize = 0;
 
@@ -187,6 +205,21 @@ public class CQLConfiguration {
             return this;
         }
 
+        /**
+         * Sets the name of local rack.
+         * <p>
+         * This local rack name will be used to setup
+         * the connection to Scylla to prioritize sending requests to
+         * the nodes in the local rack (in local datacenter).
+         *
+         * @param localRackName the name of local rack to set.
+         * @return a reference to this builder.
+         */
+        public Builder withLocalRackName(String localRackName) {
+            this.localRackName = Preconditions.checkNotNull(localRackName);
+            return this;
+        }
+
         public Builder withSslConfig(SslConfig sslConfig) {
             this.sslConfig = sslConfig;
             return this;
@@ -204,7 +237,7 @@ public class CQLConfiguration {
         }
 
         public CQLConfiguration build() {
-            return new CQLConfiguration(contactPoints, user, password, consistencyLevel, localDCName, sslConfig, queryOptionsFetchSize);
+            return new CQLConfiguration(contactPoints, user, password, consistencyLevel, localDCName, localRackName, sslConfig, queryOptionsFetchSize);
         }
     }
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/CQLConfiguration.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/CQLConfiguration.java
@@ -64,12 +64,13 @@ public class CQLConfiguration {
     private final ConsistencyLevel consistencyLevel;
     private final String localDCName;
     private final String localRackName;
+    private final ReplicaOrdering replicaOrdering;
     public final SslConfig sslConfig;
     public final int queryOptionsFetchSize;
 
     private CQLConfiguration(List<InetSocketAddress> contactPoints,
                             String user, String password, ConsistencyLevel consistencyLevel,
-                            String localDCName, String localRackName, SslConfig sslConfig, int queryOptionsFetchSize) {
+                            String localDCName, String localRackName, ReplicaOrdering replicaOrdering, SslConfig sslConfig, int queryOptionsFetchSize) {
         this.contactPoints = Preconditions.checkNotNull(contactPoints);
         Preconditions.checkArgument(!contactPoints.isEmpty());
 
@@ -83,6 +84,7 @@ public class CQLConfiguration {
         this.consistencyLevel = Preconditions.checkNotNull(consistencyLevel);
         this.localDCName = localDCName;
         this.localRackName = localRackName;
+        this.replicaOrdering = Preconditions.checkNotNull(replicaOrdering);
         this.sslConfig = sslConfig;
         this.queryOptionsFetchSize = queryOptionsFetchSize;
     }
@@ -131,6 +133,18 @@ public class CQLConfiguration {
         return localRackName;
     }
 
+    /**
+     * Returns replica ordering.
+     * <p>
+     * Replica ordering defines how CQL driver iterates over data replicas
+     * when reads from CDC tables.
+     *
+     * @return replica ordering
+     */
+    public ReplicaOrdering getReplicaOrdering() {
+        return replicaOrdering;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -142,6 +156,7 @@ public class CQLConfiguration {
         private ConsistencyLevel consistencyLevel = DEFAULT_CONSISTENCY_LEVEL;
         private String localDCName = null;
         private String localRackName = null;
+        private ReplicaOrdering replicaOrdering = ReplicaOrdering.RANDOM;
         private SslConfig sslConfig = null;
         private int queryOptionsFetchSize = 0;
 
@@ -220,6 +235,20 @@ public class CQLConfiguration {
             return this;
         }
 
+        /**
+         * Sets the replica ordering for load balancing policy.
+         * <p>
+         * It allows to change the way reader iterates over data replicas
+         * when read data from
+         *
+         * @param replicaOrdering replica ordering to set.
+         * @return a reference to this builder.
+         */
+        public Builder withReplicaOrdering(ReplicaOrdering replicaOrdering) {
+            this.replicaOrdering = Preconditions.checkNotNull(replicaOrdering);
+            return this;
+        }
+
         public Builder withSslConfig(SslConfig sslConfig) {
             this.sslConfig = sslConfig;
             return this;
@@ -237,7 +266,7 @@ public class CQLConfiguration {
         }
 
         public CQLConfiguration build() {
-            return new CQLConfiguration(contactPoints, user, password, consistencyLevel, localDCName, localRackName, sslConfig, queryOptionsFetchSize);
+            return new CQLConfiguration(contactPoints, user, password, consistencyLevel, localDCName, localRackName, replicaOrdering, sslConfig, queryOptionsFetchSize);
         }
     }
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/ReplicaOrdering.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/ReplicaOrdering.java
@@ -1,0 +1,12 @@
+package com.scylladb.cdc.cql;
+
+/**
+ A copy-cat TokenAwarePolicy.ReplicaOrdering of the driver
+ Needed here not to leak driver types
+ */
+public enum ReplicaOrdering {
+	TOPOLOGICAL,
+	RANDOM,
+	NEUTRAL;
+}
+

--- a/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Session.java
+++ b/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Session.java
@@ -2,6 +2,7 @@ package com.scylladb.cdc.cql.driver3;
 
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.scylladb.cdc.cql.CQLConfiguration;
 import com.scylladb.cdc.cql.SslConfig;
 import io.netty.handler.ssl.SslContext;
@@ -113,7 +114,8 @@ public class Driver3Session implements AutoCloseable {
 
         if (cqlConfiguration.getLocalDCName() != null) {
             clusterBuilder = clusterBuilder.withLoadBalancingPolicy(
-                    DCAwareRoundRobinPolicy.builder().withLocalDc(cqlConfiguration.getLocalDCName()).build());
+                new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().withLocalDc(cqlConfiguration.getLocalDCName()).build())
+            );
         }
 
         if (cqlConfiguration.queryOptionsFetchSize > 0) {

--- a/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Session.java
+++ b/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Session.java
@@ -2,6 +2,7 @@ package com.scylladb.cdc.cql.driver3;
 
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import com.datastax.driver.core.policies.RoundRobinPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.scylladb.cdc.cql.CQLConfiguration;
 import com.scylladb.cdc.cql.SslConfig;
@@ -115,6 +116,10 @@ public class Driver3Session implements AutoCloseable {
         if (cqlConfiguration.getLocalDCName() != null) {
             clusterBuilder = clusterBuilder.withLoadBalancingPolicy(
                 new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().withLocalDc(cqlConfiguration.getLocalDCName()).build())
+            );
+        } else {
+            clusterBuilder = clusterBuilder.withLoadBalancingPolicy(
+                new TokenAwarePolicy(new RoundRobinPolicy())
             );
         }
 

--- a/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Session.java
+++ b/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Session.java
@@ -2,6 +2,7 @@ package com.scylladb.cdc.cql.driver3;
 
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import com.datastax.driver.core.policies.RackAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.RoundRobinPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
 import com.scylladb.cdc.cql.CQLConfiguration;
@@ -113,7 +114,15 @@ public class Driver3Session implements AutoCloseable {
             clusterBuilder = clusterBuilder.withCredentials(user, password);
         }
 
-        if (cqlConfiguration.getLocalDCName() != null) {
+        if (cqlConfiguration.getLocalRackName() != null) {
+            RackAwareRoundRobinPolicy.Builder builder = RackAwareRoundRobinPolicy.builder().withLocalRack(cqlConfiguration.getLocalRackName());
+            if (cqlConfiguration.getLocalDCName() != null) {
+                builder = builder.withLocalDc(cqlConfiguration.getLocalDCName());
+            }
+            clusterBuilder = clusterBuilder.withLoadBalancingPolicy(
+                new TokenAwarePolicy(builder.build())
+            );
+        } else if (cqlConfiguration.getLocalDCName() != null) {
             clusterBuilder = clusterBuilder.withLoadBalancingPolicy(
                 new TokenAwarePolicy(DCAwareRoundRobinPolicy.builder().withLocalDc(cqlConfiguration.getLocalDCName()).build())
             );


### PR DESCRIPTION
Following changes:
1. Make load balancing policy token aware when local-dc is provided, it used to be just dc-aware, probably by mistake
2. Make default load balancing policy cluster-wide token aware, before it was token and dc-aware, with random dc.
3. Implement `localRackName` option that allows to target particular rack
4. Implement `replicaOrdering` to change how token-aware load balancing policy iterates over replicas.