### PR TITLE
Update ExponentialRetryBackoffWithJitter

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/ExponentialRetryBackoffWithJitter.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/ExponentialRetryBackoffWithJitter.java
@@ -2,21 +2,41 @@ package com.scylladb.cdc.model;
 
 import com.google.common.base.Preconditions;
 
-import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 public class ExponentialRetryBackoffWithJitter implements RetryBackoff {
-    private final Random random;
     private final int maximumBackoffMs;
     private final int backoffBase;
+    private final double jitterPercentage;
+    private final int maxJitterMs;
 
-    public ExponentialRetryBackoffWithJitter(int backoffBase, int maximumBackoffMs) {
+    public ExponentialRetryBackoffWithJitter(int backoffBase, int maximumBackoffMs, double jitterPercentage) {
         Preconditions.checkArgument(maximumBackoffMs > 0);
         this.maximumBackoffMs = maximumBackoffMs;
 
         Preconditions.checkArgument(backoffBase > 0);
         this.backoffBase = backoffBase;
 
-        this.random = new Random();
+        Preconditions.checkArgument(jitterPercentage > 0.0);
+        Preconditions.checkArgument(jitterPercentage <= 1.0);
+        this.jitterPercentage = jitterPercentage;
+
+        this.maxJitterMs = maximumBackoffMs;
+    }
+
+    public ExponentialRetryBackoffWithJitter(int backoffBase, int maximumBackoffMs, double jitterPercentage, int maxJitterMs) {
+        Preconditions.checkArgument(maximumBackoffMs > 0);
+        this.maximumBackoffMs = maximumBackoffMs;
+
+        Preconditions.checkArgument(backoffBase > 0);
+        this.backoffBase = backoffBase;
+
+        Preconditions.checkArgument(jitterPercentage > 0.0);
+        Preconditions.checkArgument(jitterPercentage <= 1.0);
+        this.jitterPercentage = jitterPercentage;
+
+        Preconditions.checkArgument(maxJitterMs >= 0.0);
+        this.maxJitterMs = Math.min(maxJitterMs, maximumBackoffMs);
     }
 
     @Override
@@ -24,8 +44,9 @@ public class ExponentialRetryBackoffWithJitter implements RetryBackoff {
         // Performing the calculation in doubles, because doing the exponentation
         // in int could result in overflow. But in case of doubles, overflow will equal
         // +Infinity. Math.min() then will properly limit it to maximumBackoffMs.
-        int backoff = (int) Math.min(maximumBackoffMs, (double) backoffBase * Math.pow(2.0, tryAttempt));
-        // Add jitter.
-        return random.nextInt(backoff);
+        double backoff = Math.min(maximumBackoffMs, (double) backoffBase * Math.pow(2.0, tryAttempt));
+        // Calculate jitter that is percentage of current backoff.
+        double jitter = Math.min(ThreadLocalRandom.current().nextDouble(jitterPercentage) * backoff, maxJitterMs);
+        return (int) (backoff - jitter);
     }
 }

--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/WorkerConfiguration.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/model/worker/WorkerConfiguration.java
@@ -15,7 +15,7 @@ public final class WorkerConfiguration {
     public static final long DEFAULT_CONFIDENCE_WINDOW_SIZE_MS = 30000;
     public static final long DEFAULT_MINIMAL_WAIT_FOR_WINDOW_MS = 0;
     public static final RetryBackoff DEFAULT_WORKER_RETRY_BACKOFF =
-            new ExponentialRetryBackoffWithJitter(10, 30000);
+            new ExponentialRetryBackoffWithJitter(50, 30000, 0.20);
 
     public final WorkerTransport transport;
     public final WorkerCQL cql;


### PR DESCRIPTION
Now it uses ThreadLocalRandom instead of shared Random.
Jitter is now settable. Previously the backoffs were random
ranging from 0 to the full value. Now setting n% jitter will subtract
randomly between 0 and n percent of current backoff value.

Default worker's base retry backoff is increased from 10ms to 50ms.
Default jitter is set at 20%.