### PR TITLE
release: migrate from oss to central portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,20 @@ name: Release scylla-cdc-java
 on:
   workflow_dispatch:
     inputs:
-      dryrun:
+      dry-run:
         type: boolean
-        description: 'dryrun: run without pushing SCM changes to upstream'
-        default: true
+        description: 'dry-run: run without pushing SCM changes to upstream'
+        default: false
+
+      skip-tests:
+        type: boolean
+        description: 'skip-tests: do not run tests while releasing'
+        default: false
+
+      target-tag:
+        type: string
+        description: 'target-tag: tag or branch name to release. Use to to re-release failed releases'
+        default: master
 
 jobs:
   release:
@@ -23,15 +33,22 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@v4
 
+      - name: Checkout Code One Commit Before ${{ inputs.target-tag }}
+        if: inputs.target-tag != 'master'
+        run: |
+          git fetch --prune --unshallow || true
+          git checkout ${{ inputs.target-tag }}~1
+          git tag -d ${{ inputs.target-tag }}
+
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
-          server-id: ossrh
+          server-id: central
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          server-username: OSSRH_USERNAME
-          server-password: OSSRH_PASSWORD
+          server-username: SONATYPE_TOKEN_USERNAME
+          server-password: SONATYPE_TOKEN_PASSWORD
 
       - name: Configure Git user
         run: |
@@ -47,18 +64,45 @@ jobs:
       - name: Prepare release
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-        run: $MVNCMD release:prepare -DpushChanges=false -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+        run: |
+          if [[ "${{ inputs.skip-tests }}" == "true" ]]; then
+            MAVEN_OPTS="${MAVEN_OPTS} -DskipTests=true -DskipITs=true"
+          fi
+          export MAVEN_OPTS
+          $MVNCMD release:prepare -DpushChanges=false -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
 
       - name: Perform release
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
-          OSSRH_PASSWORD: ${{ secrets.OSSRH_PASSWORD }}
-        if: ${{ github.event.inputs.dryrun == 'false' }}
-        run: $MVNCMD release:perform -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }}
+          SONATYPE_TOKEN_USERNAME: ${{ secrets.SONATYPE_TOKEN_USERNAME }}
+          SONATYPE_TOKEN_PASSWORD: ${{ secrets.SONATYPE_TOKEN_PASSWORD }}
+        run: |
+          CMD_OPTS=""
+          if [[ "${{ inputs.dry-run }}" != "true" ]]; then
+            CMD_OPTS="-Drelease.autopublish=true"
+          fi
+          if [[ "${{ inputs.skip-tests }}" == "true" ]]; then
+            MAVEN_OPTS="${MAVEN_OPTS} -DskipTests=true -DskipITs=true"
+          fi
+          export MAVEN_OPTS
+          $MVNCMD release:perform $CMD_OPTS -Dgpg.passphrase=${{ secrets.GPG_PASSPHRASE }} > >(tee /tmp/logs-stdout.log) 2> >(tee /tmp/logs-stderr.log)
+
+      - name: Upload stdout.log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-stdout
+          path: /tmp/logs-stdout.log
+
+      - name: Upload stderr.log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: maven-stderr
+          path: /tmp/logs-stderr.log
 
       - name: Push changes to SCM
-        if: ${{ github.event.inputs.dryrun == 'false' }}
+        if: ${{ inputs.dry-run == 'false' && inputs.target-tag == 'master' }}
         run: |
           git status && git log -3
           git push origin --follow-tags -v

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,7 @@
     <description>A library for reading the Scylla CDC log.</description>
     <url>https://github.com/scylladb/scylla-cdc-java</url>
     <inceptionYear>2020</inceptionYear>
+
     <modules>
         <module>scylla-cdc-base</module>
         <module>scylla-cdc-lib</module>
@@ -21,6 +22,8 @@
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
         <flogger.version>0.8</flogger.version>
+        <gpg.passphrase/>
+        <release.autopublish>false</release.autopublish>
     </properties>
 
     <dependencyManagement>
@@ -66,7 +69,6 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.5.2</version>
                     <configuration>
                         <systemPropertyVariables>
                             <property>
@@ -78,27 +80,57 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
                     <configuration>
                         <tagNameFormat>scylla-cdc-@{project.version}</tagNameFormat>
                         <autoVersionSubmodules>true</autoVersionSubmodules>
-                        <!-- useReleaseProfile>false</useReleaseProfile>
                         <releaseProfiles>release</releaseProfiles>
-                        <goals>deploy</goals-->
+                        <useReleaseProfile>false</useReleaseProfile>
                         <localCheckout>true</localCheckout>
                         <pushChanges>false</pushChanges>
-                        <arguments>-Dgpg.passphrase=${gpg.passphrase}</arguments>
+                        <arguments>-Dgpg.passphrase=${gpg.passphrase} -Drelease.autopublish=${release.autopublish}</arguments>
                     </configuration>
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.maven.scm</groupId>
                             <artifactId>maven-scm-provider-gitexe</artifactId>
-                            <version>1.9.5</version>
+                            <version>2.1.0</version>
                         </dependency>
                     </dependencies>
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.3</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-gpg-plugin</artifactId>
+                <version>3.2.7</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-install-plugin</artifactId>
+                <version>3.1.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>3.1.4</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>3.1.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <version>0.8.0</version>
+            </plugin>
+        </plugins>
     </build>
 
     <!--
@@ -119,7 +151,6 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.4</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -149,8 +180,6 @@
                             </execution>
                         </executions>
                     </plugin>
-                    <!--
-                    TODO: re-enable when there are javadocs.
                     <plugin>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <executions>
@@ -162,11 +191,9 @@
                             </execution>
                         </executions>
                     </plugin>
-                    -->
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>3.2.4</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>
@@ -184,14 +211,14 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
-                            <!-- skipLocalStaging>true</skipLocalStaging -->
+                            <publishingServerId>central</publishingServerId>
+                            <excludeArtifacts>scylla-cdc-printer,scylla-cdc-replicator</excludeArtifacts>
+                            <autoPublish>${release.autopublish}</autoPublish>
+                            <waitUntil>validated</waitUntil>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -217,12 +244,12 @@
 
     <distributionManagement>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
         </snapshotRepository>
         <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-releases</url>
         </repository>
     </distributionManagement>
 

--- a/scylla-cdc-printer/pom.xml
+++ b/scylla-cdc-printer/pom.xml
@@ -13,7 +13,6 @@
         <plugins>
             <plugin>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.2.4</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -21,7 +20,6 @@
 
             <plugin>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>2.4</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -29,29 +27,12 @@
 
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>2.7</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-    <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <configuration>
-                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
     <dependencies>
         <dependency>
             <groupId>com.scylladb</groupId>

--- a/scylla-cdc-replicator/pom.xml
+++ b/scylla-cdc-replicator/pom.xml
@@ -44,9 +44,9 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <artifactId>maven-gpg-plugin</artifactId>
-                <version>3.2.4</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -54,7 +54,6 @@
 
             <plugin>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>3.1.4</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -62,7 +61,6 @@
 
             <plugin>
                 <artifactId>maven-deploy-plugin</artifactId>
-                <version>3.1.4</version>
                 <configuration>
                     <skip>true</skip>
                 </configuration>
@@ -156,21 +154,6 @@
         </plugins>
     </build>
     <profiles>
-        <profile>
-            <id>release</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <configuration>
-                            <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        
         <profile>
             <id>skip-integration-tests</id>
             <activation>


### PR DESCRIPTION
Sonatype support of oss ends in July 2025.
We need to move to new API and plugins before it happens.