### PR TITLE
Update scylla driver core to 3.11.5.8

### DIFF
--- a/scylla-cdc-driver3/pom.xml
+++ b/scylla-cdc-driver3/pom.xml
@@ -13,7 +13,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <scylla.driver.version>3.11.5.7</scylla.driver.version>
+        <scylla.driver.version>3.11.5.8</scylla.driver.version>
 
         <log4j.version>2.17.1</log4j.version>
 
@@ -33,6 +33,7 @@
             <groupId>com.scylladb</groupId>
             <artifactId>scylla-driver-core</artifactId>
             <version>${scylla.driver.version}</version>
+            <type>jar</type>
             <exclusions>
                 <exclusion>
                     <groupId>com.google.guava</groupId>

--- a/scylla-cdc-replicator/pom.xml
+++ b/scylla-cdc-replicator/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <scylla.driver.version>3.11.5.7</scylla.driver.version>
+        <scylla.driver.version>3.11.5.8</scylla.driver.version>
 
         <!-- Integration tests. -->
         <docker.skip>false</docker.skip>
@@ -186,6 +186,7 @@
             <groupId>com.scylladb</groupId>
             <artifactId>scylla-driver-core</artifactId>
             <version>${scylla.driver.version}</version>
+            <type>jar</type>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
POM file is broken, we have to switch to jar.