### PR TITLE
Update scylla-driver to 3.11.5.10

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     </modules>
 
     <properties>
-        <scylla.driver.version>3.11.5.9</scylla.driver.version>
+        <scylla.driver.version>3.11.5.10</scylla.driver.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
It hold important fix: https://github.com/scylladb/java-driver/pull/757
That will help it readers survive through cluster update from version without `SCYLLA_USE_METADATA_ID` feature to version with it.
 