### PR TITLE
Fixed workersCount overriding

### DIFF
--- a/scylla-cdc-lib/src/main/java/com/scylladb/cdc/lib/CDCConsumer.java
+++ b/scylla-cdc-lib/src/main/java/com/scylladb/cdc/lib/CDCConsumer.java
@@ -104,7 +104,6 @@ public final class CDCConsumer implements AutoCloseable {
                 = WorkerConfiguration.builder();
 
         private int workersCount = getDefaultWorkersCount();
-        private Supplier<ScheduledExecutorService> executorServiceSupplier = getDefaultExecutorServiceSupplier();
         private Function<Driver3Session, WorkerCQL> workerCQLProvider = Driver3WorkerCQL::new;
 
         @SuppressWarnings("deprecation")
@@ -263,6 +262,7 @@ public final class CDCConsumer implements AutoCloseable {
         }
 
         public CDCConsumer build() {
+            Supplier<ScheduledExecutorService> executorServiceSupplier = getDefaultExecutorServiceSupplier(workersCount);
             return new CDCConsumer(cqlConfigurationBuilder.build(),
                     masterConfigurationBuilder, workerConfigurationBuilder, executorServiceSupplier, workerCQLProvider);
         }
@@ -272,7 +272,7 @@ public final class CDCConsumer implements AutoCloseable {
             return result > 0 ? result : 1;
         }
 
-        private Supplier<ScheduledExecutorService> getDefaultExecutorServiceSupplier() {
+        private static Supplier<ScheduledExecutorService> getDefaultExecutorServiceSupplier(int workersCount) {
             return () -> {
                 final ScheduledThreadPoolExecutor executor =
                         new ScheduledThreadPoolExecutor(workersCount);


### PR DESCRIPTION
`CDCConsumer.Builder#withWorkersCount(int workersCount)` is not working properly. `CDCConsumer.Builder#getDefaultExecutorServiceSupplier(int workersCount)` is always called with the default number of workers (i.e. processor count - 1) ignoring any custom value set by with-method.

Moved `executorServiceSupplier` instantiation to `build()`.