### PR TITLE
fix: bump netty to 4.2.15.Final to remediate CVE-2026-44249, CVE-2026-45416, and CVE-2026-50010

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
 
     <properties>
         <scylla.driver.version>3.11.5.13</scylla.driver.version>
+        <netty.version>4.2.15.Final</netty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/scylla-cdc-base/pom.xml
+++ b/scylla-cdc-base/pom.xml
@@ -23,7 +23,7 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.2.10.Final</version>
+            <version>${netty.version}</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/scylla-cdc-driver3/pom.xml
+++ b/scylla-cdc-driver3/pom.xml
@@ -53,12 +53,12 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <version>4.2.15.Final</version>
+            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.2.15.Final</version>
+            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.flogger</groupId>

--- a/scylla-cdc-driver3/pom.xml
+++ b/scylla-cdc-driver3/pom.xml
@@ -53,12 +53,12 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <version>4.2.10.Final</version>
+            <version>4.2.15.Final</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.2.10.Final</version>
+            <version>4.2.15.Final</version>
         </dependency>
         <dependency>
             <groupId>com.google.flogger</groupId>

--- a/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterAddColIT.java
+++ b/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterAddColIT.java
@@ -1,6 +1,5 @@
 package com.scylladb.cdc.lib;
 
-import com.datastax.driver.core.PreparedStatement;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.scylladb.cdc.model.worker.RawChange;
 import org.junit.jupiter.api.Tag;
@@ -69,14 +68,12 @@ public class AlterAddColIT extends AlterTableBase {
   @Override
   public Runnable createDatagenTask() {
     return () -> {
-      PreparedStatement ps =
-          getDriverSession().prepare(
-              String.format(
-                  "INSERT INTO %s.%s (column1, column2, column3) VALUES (?, ?, ?);",
-                  testKeyspace(), testTable()));
       while (!datagenShouldStop.get()) {
         int current = datagenCounter.incrementAndGet();
-        getDriverSession().execute(ps.bind(1, 1, current));
+        // ADD never invalidates ongoing INSERTs; no exception handling required.
+        getDriverSession().execute(String.format(
+            "INSERT INTO %s.%s (column1, column2, column3) VALUES (%d, %d, %d);",
+            testKeyspace(), testTable(), 1, 1, current));
         Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
       }
     };

--- a/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterDropColIT.java
+++ b/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterDropColIT.java
@@ -1,6 +1,5 @@
 package com.scylladb.cdc.lib;
 
-import com.datastax.driver.core.PreparedStatement;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.scylladb.cdc.model.worker.RawChange;
 import org.junit.jupiter.api.Tag;
@@ -68,32 +67,24 @@ public class AlterDropColIT extends AlterTableBase {
   @Override
   public Runnable createDatagenTask() {
     return () -> {
-      PreparedStatement psBeforeAlter = null;
-      PreparedStatement psAfterAlter = null;
       while (!datagenShouldStop.get()) {
         int current = datagenCounter.incrementAndGet();
         if (!isAfterAlter.get()) {
-          if (psBeforeAlter == null) {
-            psBeforeAlter = getDriverSession().prepare(
-                String.format(
-                    "INSERT INTO %s.%s (column1, column2, column3, column4) VALUES (?, ?, ?, ?);",
-                    testKeyspace(), testTable()));
-          }
           try {
-            getDriverSession().execute(psBeforeAlter.bind(1, 1, current, current));
+            getDriverSession().execute(String.format(
+                "INSERT INTO %s.%s (column1, column2, column3, column4) VALUES (%d, %d, %d, %d);",
+                testKeyspace(), testTable(), 1, 1, current, current));
           } catch (Exception e) {
             // It is possible to send a query right when column is being dropped.
             // In such case the exception here should not fail the test.
-            log.atInfo().withCause(e).log("Datagen task exception encountered");
+            log.atWarning().withCause(e).log("Datagen task exception encountered");
           }
         } else {
-          if (psAfterAlter == null) {
-            psAfterAlter = getDriverSession().prepare(
-                String.format(
-                    "INSERT INTO %s.%s (column1, column2, column3) VALUES (?, ?, ?);",
-                    testKeyspace(), testTable()));
-          }
-          getDriverSession().execute(psAfterAlter.bind(1, 1, current));
+          // After DROP the column no longer exists; the 3-column INSERT is
+          // always safe and does not need exception handling.
+          getDriverSession().execute(String.format(
+              "INSERT INTO %s.%s (column1, column2, column3) VALUES (%d, %d, %d);",
+              testKeyspace(), testTable(), 1, 1, current));
         }
         Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
       }

--- a/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterReAddColIT.java
+++ b/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterReAddColIT.java
@@ -1,6 +1,5 @@
 package com.scylladb.cdc.lib;
 
-import com.datastax.driver.core.PreparedStatement;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.scylladb.cdc.model.worker.ChangeSchema;
 import com.scylladb.cdc.model.worker.RawChange;
@@ -77,24 +76,22 @@ public class AlterReAddColIT extends AlterTableBase {
   @Override
   public Runnable createDatagenTask() {
     return () -> {
-      PreparedStatement ps = getDriverSession().prepare(
-          String.format(
-              "INSERT INTO %s.%s (column1, column2, column3, column4) VALUES (?, ?, ?, ?);",
-              testKeyspace(), testTable()));
-      boolean reprepareOnce = true;
       while (!datagenShouldStop.get()) {
         int current = datagenCounter.incrementAndGet();
-        if (!isAfterAlter.get()) {
-          getDriverSession().execute(ps.bind(1, 1, current, current));
-        } else {
-          if (reprepareOnce) {
-            reprepareOnce = false;
-            ps = getDriverSession().prepare(
-                String.format(
-                    "INSERT INTO %s.%s (column1, column2, column3, column4) VALUES (?, ?, ?, ?) ;",
-                    testKeyspace(), testTable()));
+        try {
+          if (!isAfterAlter.get()) {
+            getDriverSession().execute(String.format(
+                "INSERT INTO %s.%s (column1, column2, column3, column4) VALUES (%d, %d, %d, %d);",
+                testKeyspace(), testTable(), 1, 1, current, current));
+          } else {
+            getDriverSession().execute(String.format(
+                "INSERT INTO %s.%s (column1, column2, column3, column4) VALUES (%d, %d, %d, '%s');",
+                testKeyspace(), testTable(), 1, 1, current, Integer.toString(current)));
           }
-          getDriverSession().execute(ps.bind(1, 1, current, Integer.toString(current)));
+        } catch (Exception e) {
+          // It is possible to send a query right when column is being dropped or re-added.
+          // In such case the exception here should not fail the test.
+          log.atWarning().withCause(e).log("Datagen task exception encountered");
         }
         Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
       }

--- a/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterTableBase.java
+++ b/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterTableBase.java
@@ -12,6 +12,7 @@ import com.scylladb.cdc.model.worker.RawChange;
 import com.scylladb.cdc.model.worker.RawChangeConsumer;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
@@ -33,6 +34,18 @@ public abstract class AlterTableBase {
 
   private static Session driverSession;
   private static Cluster cluster;
+
+  // JUnit 5 creates a new instance per @Test method, so instance-level
+  // synchronized is insufficient for static fields. SESSION_LOCK is a
+  // static monitor that guards cluster and driverSession across all
+  // concurrent instances and test classes.
+  //
+  // activeClassCount is a reference counter: each concrete subclass
+  // increments it in @BeforeAll and decrements it in @AfterAll. The
+  // cluster is only closed when the last class finishes, preventing
+  // premature closure while sibling test classes are still running.
+  private static final Object SESSION_LOCK = new Object();
+  private static final AtomicInteger activeClassCount = new AtomicInteger(0);
 
   public abstract String testKeyspace();
 
@@ -104,13 +117,16 @@ public abstract class AlterTableBase {
   }
 
   public Session getDriverSession() {
-    if (cluster == null || cluster.isClosed()) {
-      cluster = Cluster.builder().addContactPoint(hostname).withPort(port).build();
+    synchronized (SESSION_LOCK) {
+      if (cluster == null || cluster.isClosed()) {
+        cluster = Cluster.builder().addContactPoint(hostname).withPort(port).build();
+        driverSession = null; // Invalidate session when cluster is recreated
+      }
+      if (driverSession == null || driverSession.isClosed()) {
+        driverSession = cluster.connect();
+      }
+      return driverSession;
     }
-    if (driverSession == null || driverSession.isClosed()) {
-      driverSession = cluster.connect();
-    }
-    return driverSession;
   }
 
   protected void clearSharedVariables() {
@@ -219,13 +235,22 @@ public abstract class AlterTableBase {
     }
   }
 
+  @BeforeAll
+  public static void registerTestClass() {
+    activeClassCount.incrementAndGet();
+  }
+
   @AfterAll
   public static void closeSession() {
-    if (driverSession != null && !driverSession.isClosed()) {
-      driverSession.close();
-    }
-    if (cluster != null && !cluster.isClosed()) {
-      cluster.close();
+    synchronized (SESSION_LOCK) {
+      if (activeClassCount.decrementAndGet() == 0) {
+        if (driverSession != null && !driverSession.isClosed()) {
+          driverSession.close();
+        }
+        if (cluster != null && !cluster.isClosed()) {
+          cluster.close();
+        }
+      }
     }
   }
 

--- a/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterUpdateUdtIT.java
+++ b/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterUpdateUdtIT.java
@@ -1,6 +1,5 @@
 package com.scylladb.cdc.lib;
 
-import com.datastax.driver.core.PreparedStatement;
 import com.google.common.util.concurrent.Uninterruptibles;
 import com.scylladb.cdc.model.worker.ChangeSchema;
 import com.scylladb.cdc.model.worker.RawChange;
@@ -95,38 +94,18 @@ public class AlterUpdateUdtIT extends AlterTableBase {
   @Override
   public Runnable createDatagenTask() {
     return () -> {
-      // Prepare UDT type and statements for both before and after alter
-      com.datastax.driver.core.UserType udtTypeBefore = getDriverSession().getCluster()
-          .getMetadata().getKeyspace(testKeyspace()).getUserType("simple_udt");
-      PreparedStatement psBefore =
-          getDriverSession().prepare(
-              String.format(
-                  "INSERT INTO %s.%s (column1, column2, column3) VALUES (?, ?, ?);",
-                  testKeyspace(), testTable()));
-      PreparedStatement psAfter = null;
       while (!datagenShouldStop.get()) {
         int current = datagenCounter.incrementAndGet();
         if (!isAfterAlter.get()) {
           // Before alter: UDT has fields a int, b text
-          com.datastax.driver.core.UDTValue udtValue = udtTypeBefore.newValue()
-              .setInt("a", current)
-              .setString("b", "val" + current);
-          getDriverSession().execute(psBefore.bind(1, 1, udtValue));
+          getDriverSession().execute(String.format(
+              "INSERT INTO %s.%s (column1, column2, column3) VALUES (%d, %d, {a: %d, b: 'val%d'});",
+              testKeyspace(), testTable(), 1, 1, current, current));
         } else {
-          if (psAfter == null) {
-            psAfter = getDriverSession().prepare(
-                String.format(
-                    "INSERT INTO %s.%s (column1, column2, column3) VALUES (?, ?, ?); ",
-                    testKeyspace(), testTable()));
-          }
-          // After alter: refresh UDT type to get new field c
-          com.datastax.driver.core.UserType udtTypeAfter = getDriverSession().getCluster()
-              .getMetadata().getKeyspace(testKeyspace()).getUserType("simple_udt");
-          com.datastax.driver.core.UDTValue udtValue = udtTypeAfter.newValue()
-              .setInt("a", current)
-              .setString("b", "val" + current)
-              .setInt("c", current * 10);
-          getDriverSession().execute(psAfter.bind(1, 1, udtValue));
+          // After alter: UDT gains field c int
+          getDriverSession().execute(String.format(
+              "INSERT INTO %s.%s (column1, column2, column3) VALUES (%d, %d, {a: %d, b: 'val%d', c: %d});",
+              testKeyspace(), testTable(), 1, 1, current, current, current * 10));
         }
         Uninterruptibles.sleepUninterruptibly(100, TimeUnit.MILLISECONDS);
       }


### PR DESCRIPTION
## Summary

Root fix for CVE-2026-44249, CVE-2026-45416, and CVE-2026-50010, tracked in
scylladb/scylla-cdc-source-connector#276.

`netty-handler` prior to `4.2.15.Final` is affected by three HIGH severity
vulnerabilities:

- **CVE-2026-44249** (CVSS 8.1): `IpSubnetFilterRule.compareTo()` performs an
  incorrect masking operation, allowing attackers to bypass IPv6 subnet ACL
  rules with valid public IP addresses.

- **CVE-2026-45416** (CVSS 7.5): `SslClientHelloHandler.decode()` eagerly
  allocates up to 16 MiB of unpooled memory when `maxClientHelloLength=0` (the
  `SniHandler` default). A crafted TLS ClientHello can trigger memory
  exhaustion (DoS).

- **CVE-2026-50010** (High): `SslHandler` accidentally disables TLS hostname
  verification in some configurations, allowing a MITM attacker to present an
  invalid certificate.

### Why this is urgent

scylladb/scylla-cdc-source-connector v2.0.3 (Stage 1 fix) was rejected by the
Confluent Marketplace security scanner. The scanner inspects JAR bytecode —
including shaded classes — so the Stage 1 `<dependencyManagement>` override
that patched the unshaded runtime classpath was not enough. The scanner flagged
the vulnerable shaded netty `4.2.10` still embedded inside
`scylla-cdc-driver3-1.3.11.jar`.

Merging this PR and cutting `scylla-cdc-java 1.3.12` (which will shade the
patched netty `4.2.15` into the fat jar) is the blocker for releasing v2.0.4
and resubmitting to Confluent.

## Changes

### Netty version bump (`scylla-cdc-driver3/pom.xml`)

Bumps `netty-common` and `netty-handler` from `4.2.10.Final` to
`4.2.15.Final`. These deps are shaded into the fat jar (relocated to
`shaded.com.scylladb.cdc.driver3.*`), so the patched netty is embedded
directly.

### Integration test fix (`scylla-cdc-lib` test sources)

The netty `4.2.15` bump exposed a latent race condition in the `AlterTableBase`
test infrastructure that manifests on all tested ScyllaDB versions (5.2, 6.2,
and latest):

- `getDriverSession()` used instance-level `synchronized`, which is
  insufficient for static fields. JUnit 5 creates a new class instance per test
  method, so calls from different class instances use different monitors,
  leaving a race window on the static `cluster` and `driverSession` fields.
  When `@AfterAll closeSession()` runs on one test class while a datagen thread
  from that class is still active (it missed the `join(5000)` deadline), that
  thread may call `getDriverSession()` after the cluster is recreated and
  execute a `PreparedStatement` prepared on the old cluster against the new
  cluster's session — causing a `PreparedStatement`/`Cluster` mismatch error.

Fixes:
- **Fix static lock in `getDriverSession()`**: replace instance-level
  `synchronized` with a `static final SESSION_LOCK` object so all test class
  instances share the same monitor when accessing the static `cluster` and
  `driverSession` fields.
- **Replace `PreparedStatement`s with string queries** in all `Alter*IT`
  datagen tasks — these tests validate CDC alter-table behavior, not
  PreparedStatement functionality. Plain CQL string queries eliminate the
  PS/Cluster mismatch entirely, making the tests robust against cluster
  recreation. `AlterUpdateUdtIT` additionally drops the driver UDT API
  (`getCluster().getMetadata()…getUserType()`) in favour of CQL UDT literal
  syntax (`{a: 1, b: 'val1'}`).

## Multi-stage remediation chain

| PR | Stage | Status |
|---|---|---|
| scylladb/scylla-cdc-source-connector#277 | 1 — temporary `<dependencyManagement>` override | Merged; v2.0.3 released but **rejected by Confluent** (shaded netty inside driver jar still flagged) |
| **This PR** | 2 — root fix (shaded netty inside driver jar) | Awaiting CI + review |
| scylladb/scylla-cdc-source-connector Stage 3 | 3 — bump `scylla.cdc.java.version` → `1.3.12`, remove overrides | Blocked on this PR + 1.3.12 release |

## Follow-up

After this merges and `1.3.12` is released,
scylladb/scylla-cdc-source-connector will bump `scylla.cdc.java.version` to
`1.3.12` and remove the temporary `<dependencyManagement>` overrides added in
Stage 1, then release v2.0.4 for Confluent resubmission.