### PR TITLE
fix(test): use NetworkTopologyStrategy in integration tests for ScyllaDB 2026.x compatibility

### DIFF
--- a/scylla-cdc-driver3/src/test/java/com/scylladb/cdc/cql/driver3/BaseScyllaIntegrationTest.java
+++ b/scylla-cdc-driver3/src/test/java/com/scylladb/cdc/cql/driver3/BaseScyllaIntegrationTest.java
@@ -3,6 +3,7 @@ package com.scylladb.cdc.cql.driver3;
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Row;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.QueryValidationException;
 import com.datastax.driver.core.querybuilder.QueryBuilder;
 import com.datastax.driver.core.schemabuilder.SchemaBuilder;
 import com.google.common.base.Preconditions;
@@ -58,12 +59,23 @@ public class BaseScyllaIntegrationTest {
         // Drop the test keyspace in case a prior cleanup was not properly executed.
         driverSession.execute(SchemaBuilder.dropKeyspace("ks").ifExists());
 
-        // Create a test keyspace.
-        driverSession.execute(SchemaBuilder.createKeyspace("ks").with().replication(
-            new HashMap<String, Object>() {{
-                put("class", "SimpleStrategy");
-                put("replication_factor", "1");
-        }}));
+        // Create a test keyspace. Tablets are disabled explicitly: ScyllaDB 6.x enables
+        // them by default for NTS and CDC is incompatible with tablets (issue #16317).
+        // On ScyllaDB < 6.0 the 'tablets' property is unknown; fall back without it.
+        try {
+            driverSession.execute(
+                "CREATE KEYSPACE ks WITH replication = " +
+                "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1} " +
+                "AND tablets = {'enabled': false}");
+        } catch (QueryValidationException e) {
+            if (e.getMessage() != null && e.getMessage().contains("Unknown property 'tablets'")) {
+                driverSession.execute(
+                    "CREATE KEYSPACE ks WITH replication = " +
+                    "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}");
+            } else {
+                throw e;
+            }
+        }
 
         maybeWaitForFirstGeneration();
     }

--- a/scylla-cdc-driver3/src/test/java/com/scylladb/cdc/cql/driver3/BaseScyllaTabletsIntegrationTest.java
+++ b/scylla-cdc-driver3/src/test/java/com/scylladb/cdc/cql/driver3/BaseScyllaTabletsIntegrationTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 @Tag("integration")
+@Tag("tablets")
 public class BaseScyllaTabletsIntegrationTest {
     private static final FluentLogger logger = FluentLogger.forEnclosingClass();
     protected static final long SCYLLA_TIMEOUT_MS = 3000;
@@ -58,17 +59,30 @@ public class BaseScyllaTabletsIntegrationTest {
         // Drop the test keyspace in case a prior cleanup was not properly executed.
         driverSession.execute(SchemaBuilder.dropKeyspace("ks").ifExists());
 
-        // Create a test keyspace with tablets enabled
+        // Gate 1: skip if this ScyllaDB version doesn't support the 'tablets' property at all.
         try {
             driverSession.execute("CREATE KEYSPACE ks " +
                 "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} " +
                 "AND tablets={'initial':2};");
         } catch (Exception e) {
             if (e.getMessage().contains("Unknown property 'tablets'")) {
-                abort(
-                    "Test aborted: This version of Scylla doesn't support CDC with tablets. " +
-                    "Error message: " + e.getMessage()
-                );
+                abort("Test skipped: this ScyllaDB version does not support the tablets property. " +
+                    "Error: " + e.getMessage());
+            }
+            throw e;
+        }
+
+        // Gate 2: skip if this ScyllaDB version doesn't support CDC on tablets keyspaces.
+        try {
+            driverSession.execute(
+                "CREATE TABLE ks.cdc_probe (pk int PRIMARY KEY) WITH cdc = {'enabled': true};");
+            driverSession.execute("DROP TABLE ks.cdc_probe;");
+        } catch (InvalidQueryException e) {
+            if (e.getMessage().contains("Cannot create CDC log for a table") &&
+                    e.getMessage().contains("because keyspace uses tablets")) {
+                driverSession.execute(SchemaBuilder.dropKeyspace("ks").ifExists());
+                abort("Test skipped: this ScyllaDB version does not support CDC with tablets. " +
+                    "Error: " + e.getMessage());
             }
             throw e;
         }
@@ -168,34 +182,4 @@ public class BaseScyllaTabletsIntegrationTest {
         }
     }
 
-    /**
-     * Attempts to create a table with CDC enabled in a tablets-mode keyspace.
-     *
-     * This method handles the specific case where a Scylla version doesn't support
-     * CDC with tablets mode by detecting the specific error message and aborting the test
-     * rather than letting it fail. This approach allows the test suite to run on both
-     * Scylla versions that support CDC with tablets and those that don't.
-     *
-     * If the table creation fails for any other reason, the original exception is rethrown
-     * so that the test fails normally, indicating a real issue rather than a feature limitation.
-     *
-     * @param query The CREATE TABLE query to execute
-     * @throws InvalidQueryException if the table cannot be created for reasons other than
-     *         CDC with tablets compatibility
-     */
-    public void tryCreateTable(String query) throws InvalidQueryException {
-        try {
-            driverSession.execute(query);
-        } catch (InvalidQueryException e) {
-            // Check if this is the specific exception about CDC logs in tablet mode
-            if (e.getMessage().contains("Cannot create CDC log for a table") &&
-                e.getMessage().contains("because keyspace uses tablets")) {
-                abort(
-                    "Test aborted: This version of Scylla doesn't support CDC with tablets. " +
-                    "Error message: " + e.getMessage()
-                );
-            }
-            throw e;
-        }
-    }
 }

--- a/scylla-cdc-driver3/src/test/java/com/scylladb/cdc/cql/driver3/Driver3MasterCQLTabletsIT.java
+++ b/scylla-cdc-driver3/src/test/java/com/scylladb/cdc/cql/driver3/Driver3MasterCQLTabletsIT.java
@@ -19,11 +19,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Tag("integration")
+@Tag("tablets")
 public class Driver3MasterCQLTabletsIT extends BaseScyllaTabletsIntegrationTest {
 
     @Test
     public void testTabletsMasterFetchesGenerationIdForTable() throws InterruptedException, ExecutionException, TimeoutException {
-        tryCreateTable("CREATE TABLE ks.test(p int, c int, v int, PRIMARY KEY(p, c)) " +
+        driverSession.execute("CREATE TABLE ks.test(p int, c int, v int, PRIMARY KEY(p, c)) " +
                 "WITH cdc = {'enabled': true}");
 
         // Check that Driver3MasterCQL can fetch the table's generation id in tablet mode

--- a/scylla-cdc-driver3/src/test/java/com/scylladb/cdc/cql/driver3/Driver3TabletsIntegrationIT.java
+++ b/scylla-cdc-driver3/src/test/java/com/scylladb/cdc/cql/driver3/Driver3TabletsIntegrationIT.java
@@ -13,11 +13,12 @@ import java.util.concurrent.TimeoutException;
 import static org.junit.jupiter.api.Assertions.*;
 
 @Tag("integration")
+@Tag("tablets")
 public class Driver3TabletsIntegrationIT extends BaseScyllaTabletsIntegrationTest {
 
     @Test
     public void testChangeInTabletsMode() throws ExecutionException, InterruptedException, TimeoutException {
-        tryCreateTable("CREATE TABLE ks.test(pk int, ck int, v text, PRIMARY KEY(pk, ck)) " +
+        driverSession.execute("CREATE TABLE ks.test(pk int, ck int, v text, PRIMARY KEY(pk, ck)) " +
                 "WITH cdc = {'enabled': true}");
 
         // Insert a test row

--- a/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterTableBase.java
+++ b/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterTableBase.java
@@ -65,11 +65,6 @@ public abstract class AlterTableBase {
     session.execute(dropKeyspaceQuery);
   }
 
-  public String createKeyspaceQuery() {
-    return String.format("CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', " + "'replication_factor" +
-        "': 1};", testKeyspace());
-  }
-
   public abstract String createTableQuery();
 
   public abstract void applyAlteration();
@@ -144,7 +139,7 @@ public abstract class AlterTableBase {
 
   protected void createKeyspaceAndTable() {
     wipeKeyspace();
-    getDriverSession().execute(createKeyspaceQuery());
+    TestKeyspaceUtils.createWithoutTablets(getDriverSession(), testKeyspace());
     getDriverSession().execute(createTableQuery());
   }
 

--- a/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterTableIT.java
+++ b/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterTableIT.java
@@ -42,10 +42,8 @@ public class AlterTableIT {
     try (Cluster cluster = Cluster.builder().addContactPoint(hostname).withPort(port).build()) {
       session = cluster.connect();
       session.execute(
-          String.format(
-              "CREATE KEYSPACE IF NOT EXISTS %s WITH replication = {'class': 'SimpleStrategy', "
-                  + "'replication_factor': 1};",
-              keyspace));
+          String.format("DROP KEYSPACE IF EXISTS %s;", keyspace));
+      TestKeyspaceUtils.createWithoutTablets(session, keyspace);
       session.execute(String.format("DROP TABLE IF EXISTS %s.%s;", keyspace, table));
       session.execute(
           String.format(

--- a/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterUpdateUdtIT.java
+++ b/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/AlterUpdateUdtIT.java
@@ -22,7 +22,7 @@ public class AlterUpdateUdtIT extends AlterTableBase {
   @Override
   protected void createKeyspaceAndTable() {
     wipeKeyspace();
-    getDriverSession().execute(createKeyspaceQuery());
+    TestKeyspaceUtils.createWithoutTablets(getDriverSession(), testKeyspace());
     getDriverSession().execute(createUdtQuery());
     getDriverSession().execute(createTableQuery());
   }

--- a/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/EmptyGenerationIT.java
+++ b/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/EmptyGenerationIT.java
@@ -41,9 +41,7 @@ public class EmptyGenerationIT {
 
       // Create keyspace without tablets enabled
       session.execute(String.format("DROP KEYSPACE IF EXISTS %s;", keyspace));
-      session.execute(String.format(
-          "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', "
-              + "'replication_factor': 1}", keyspace));
+      TestKeyspaceUtils.createWithoutTablets(session, keyspace);
 
       session.execute(String.format("DROP TABLE IF EXISTS %s.%s;", keyspace, table));
       session.execute(

--- a/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/FirstStartupLatencyIT.java
+++ b/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/FirstStartupLatencyIT.java
@@ -46,9 +46,7 @@ public class FirstStartupLatencyIT {
             Session session = cluster.connect();
 
             session.execute(String.format("DROP KEYSPACE IF EXISTS %s;", keyspace));
-            session.execute(String.format(
-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', "
-                    + "'replication_factor': 1};", keyspace));
+            TestKeyspaceUtils.createWithoutTablets(session, keyspace);
             session.execute(String.format(
                 "CREATE TABLE %s.%s (pk int, ck int, v text, PRIMARY KEY (pk, ck)) "
                     + "WITH cdc = {'enabled': true};",
@@ -127,9 +125,7 @@ public class FirstStartupLatencyIT {
             Session session = cluster.connect();
 
             session.execute(String.format("DROP KEYSPACE IF EXISTS %s;", keyspace));
-            session.execute(String.format(
-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', "
-                    + "'replication_factor': 1};", keyspace));
+            TestKeyspaceUtils.createWithoutTablets(session, keyspace);
             session.execute(String.format(
                 "CREATE TABLE %s.%s (pk int, ck int, v text, PRIMARY KEY (pk, ck)) "
                     + "WITH cdc = {'enabled': true};",
@@ -201,9 +197,7 @@ public class FirstStartupLatencyIT {
             Session session = cluster.connect();
 
             session.execute(String.format("DROP KEYSPACE IF EXISTS %s;", keyspace));
-            session.execute(String.format(
-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', "
-                    + "'replication_factor': 1};", keyspace));
+            TestKeyspaceUtils.createWithoutTablets(session, keyspace);
             session.execute(String.format(
                 "CREATE TABLE %s.%s (pk int, ck int, v text, PRIMARY KEY (pk, ck)) "
                     + "WITH cdc = {'enabled': true};",

--- a/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/PreimagePostimageIT.java
+++ b/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/PreimagePostimageIT.java
@@ -42,9 +42,7 @@ public class PreimagePostimageIT {
 
             // Create keyspace
             session.execute(String.format("DROP KEYSPACE IF EXISTS %s;", keyspace));
-            session.execute(String.format(
-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', "
-                    + "'replication_factor': 1};", keyspace));
+            TestKeyspaceUtils.createWithoutTablets(session, keyspace);
 
             // Create table with CDC, preimage, and postimage enabled
             session.execute(String.format(
@@ -160,9 +158,7 @@ public class PreimagePostimageIT {
 
             // Create keyspace
             session.execute(String.format("DROP KEYSPACE IF EXISTS %s;", keyspace));
-            session.execute(String.format(
-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', "
-                    + "'replication_factor': 1};", keyspace));
+            TestKeyspaceUtils.createWithoutTablets(session, keyspace);
 
             // Create table with CDC and preimage enabled
             session.execute(String.format(
@@ -248,9 +244,7 @@ public class PreimagePostimageIT {
 
             // Create keyspace
             session.execute(String.format("DROP KEYSPACE IF EXISTS %s;", keyspace));
-            session.execute(String.format(
-                "CREATE KEYSPACE %s WITH replication = {'class': 'SimpleStrategy', "
-                    + "'replication_factor': 1};", keyspace));
+            TestKeyspaceUtils.createWithoutTablets(session, keyspace);
 
             // Create table with CDC and postimage enabled (no preimage)
             session.execute(String.format(

--- a/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/TabletsIT.java
+++ b/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/TabletsIT.java
@@ -18,10 +18,12 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
 @Tag("integration")
+@Tag("tablets")
 public class TabletsIT {
   Properties systemProperties = System.getProperties();
   String hostname =
@@ -29,6 +31,43 @@ public class TabletsIT {
   int port = Integer.parseInt(systemProperties.getProperty("scylla.docker.port"));
   String scyllaVersion =
       Preconditions.checkNotNull(systemProperties.getProperty("scylla.docker.version"));
+
+  @BeforeEach
+  public void checkTabletsCdcSupport() {
+    try (Cluster cluster = Cluster.builder().addContactPoint(hostname).withPort(port).build();
+         Session session = cluster.connect()) {
+      // Drop probe keyspace in case it was left from a prior interrupted run.
+        session.execute("DROP KEYSPACE IF EXISTS cdc_tablets_probe;");
+
+      // Gate 1: skip if this ScyllaDB version doesn't support the 'tablets' property at all.
+      try {
+        session.execute("CREATE KEYSPACE cdc_tablets_probe " +
+            "WITH replication = {'class': 'NetworkTopologyStrategy', 'replication_factor': 1} " +
+            "AND tablets = {'initial': 2};");
+      } catch (Exception e) {
+        if (e.getMessage().contains("Unknown property 'tablets'")) {
+          abort("Test skipped: this ScyllaDB version does not support the tablets property. " +
+              "Error: " + e.getMessage());
+        }
+        throw e;
+      }
+
+      // Gate 2: skip if this ScyllaDB version doesn't support CDC on tablets keyspaces.
+      try {
+        session.execute(
+            "CREATE TABLE cdc_tablets_probe.t (pk int PRIMARY KEY) WITH cdc = {'enabled': true};");
+      } catch (InvalidQueryException e) {
+        if (e.getMessage().contains("Cannot create CDC log for a table") &&
+            e.getMessage().contains("because keyspace uses tablets")) {
+          abort("Test skipped: this ScyllaDB version does not support CDC with tablets. " +
+              "Error: " + e.getMessage());
+        }
+        throw e;
+      } finally {
+      session.execute("DROP KEYSPACE IF EXISTS cdc_tablets_probe;");
+      }
+    }
+  }
 
   @Test
   public void consumeFromTabletsKeyspace() throws InterruptedException {
@@ -41,13 +80,12 @@ public class TabletsIT {
 
       // Create keyspace with tablets enabled
       session.execute(String.format("DROP KEYSPACE IF EXISTS %s;", keyspace));
-      tryCreateKeyspace(session, String.format(
+      session.execute(String.format(
           "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', "
               + "'replication_factor': 1} AND tablets = {'initial': 8};", keyspace));
 
       session.execute(String.format("DROP TABLE IF EXISTS %s.%s;", keyspace, table));
-      tryCreateTable(session,
-          String.format(
+      session.execute(String.format(
               "CREATE TABLE %s.%s (id int, value text, PRIMARY KEY (id)) "
                   + "WITH cdc = {'enabled': 'true'};",
               keyspace, table));
@@ -111,7 +149,7 @@ public class TabletsIT {
 
       // Create keyspace with tablets enabled
       session.execute(String.format("DROP KEYSPACE IF EXISTS %s;", keyspace));
-      tryCreateKeyspace(session, String.format(
+      session.execute(String.format(
           "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', "
               + "'replication_factor': 1} AND tablets = {'initial': 8};", keyspace));
 
@@ -119,14 +157,12 @@ public class TabletsIT {
       session.execute(String.format("DROP TABLE IF EXISTS %s.%s;", keyspace, table1));
       session.execute(String.format("DROP TABLE IF EXISTS %s.%s;", keyspace, table2));
 
-      tryCreateTable(session,
-          String.format(
+      session.execute(String.format(
               "CREATE TABLE %s.%s (id int, value text, PRIMARY KEY (id)) "
                   + "WITH cdc = {'enabled': 'true'};",
               keyspace, table1));
 
-      tryCreateTable(session,
-          String.format(
+      session.execute(String.format(
               "CREATE TABLE %s.%s (id int, name text, PRIMARY KEY (id)) "
                   + "WITH cdc = {'enabled': 'true'};",
               keyspace, table2));
@@ -195,13 +231,12 @@ public class TabletsIT {
 
       // Create keyspace with tablets enabled
       session.execute(String.format("DROP KEYSPACE IF EXISTS %s;", keyspace));
-      tryCreateKeyspace(session, String.format(
+      session.execute(String.format(
           "CREATE KEYSPACE %s WITH replication = {'class': 'NetworkTopologyStrategy', "
               + "'replication_factor': 1} AND tablets = {'initial': 8};", keyspace));
 
       session.execute(String.format("DROP TABLE IF EXISTS %s.%s;", keyspace, table));
-      tryCreateTable(session,
-          String.format(
+      session.execute(String.format(
               "CREATE TABLE %s.%s (id int, value text, PRIMARY KEY (id)) "
                   + "WITH cdc = {'enabled': 'true'};",
               keyspace, table));
@@ -318,28 +353,4 @@ public class TabletsIT {
     }
   }
 
-  public void tryCreateKeyspace(Session session, String query) {
-      try {
-          session.execute(query);
-      } catch (Exception e) {
-          if (e.getMessage().contains("Unknown property 'tablets'")) {
-              abort("Test aborted: This version of Scylla doesn't support CDC with tablets. " +
-                              "Error message: " + e.getMessage());
-          }
-          throw e;
-      }
-  }
-
-  public void tryCreateTable(Session session, String query) throws InvalidQueryException {
-      try {
-          session.execute(query);
-      } catch (InvalidQueryException e) {
-          if (e.getMessage().contains("Cannot create CDC log for a table") &&
-                  e.getMessage().contains("because keyspace uses tablets")) {
-              abort("Test aborted: This version of Scylla doesn't support CDC with tablets. " +
-                              "Error message: " + e.getMessage());
-          }
-          throw e;
-      }
-  }
 }

--- a/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/TestKeyspaceUtils.java
+++ b/scylla-cdc-lib/src/test/java/com/scylladb/cdc/lib/TestKeyspaceUtils.java
@@ -1,0 +1,45 @@
+package com.scylladb.cdc.lib;
+
+import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.QueryValidationException;
+
+/**
+ * Utility methods for managing keyspaces in integration tests.
+ */
+class TestKeyspaceUtils {
+
+    private TestKeyspaceUtils() {}
+
+    /**
+     * Creates a keyspace with tablet replication explicitly disabled.
+     *
+     * ScyllaDB 6.x enables tablet replication by default for NetworkTopologyStrategy
+     * keyspaces. CDC is incompatible with tablets (issue #16317). This method
+     * attempts to create the keyspace with {@code AND tablets = {'enabled': false}}
+     * to opt out of tablets. On ScyllaDB versions that do not support the
+     * {@code tablets} property (< 6.0), it falls back to creating the keyspace
+     * without the clause; tablets are not active on those versions anyway.
+     *
+     * @param session   the driver session to use
+     * @param keyspace  the keyspace name
+     */
+    static void createWithoutTablets(Session session, String keyspace) {
+        try {
+            session.execute(String.format(
+                "CREATE KEYSPACE %s WITH replication = " +
+                "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1} " +
+                "AND tablets = {'enabled': false}",
+                keyspace));
+        } catch (QueryValidationException e) {
+            if (e.getMessage() != null && e.getMessage().contains("Unknown property 'tablets'")) {
+                // ScyllaDB < 6.0: tablets not supported; NTS without the clause is fine.
+                session.execute(String.format(
+                    "CREATE KEYSPACE %s WITH replication = " +
+                    "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}",
+                    keyspace));
+            } else {
+                throw e;
+            }
+        }
+    }
+}

--- a/scylla-cdc-replicator/src/test/java/com/scylladb/cdc/replicator/BaseScyllaIntegrationTest.java
+++ b/scylla-cdc-replicator/src/test/java/com/scylladb/cdc/replicator/BaseScyllaIntegrationTest.java
@@ -2,6 +2,7 @@ package com.scylladb.cdc.replicator;
 
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
+import com.datastax.driver.core.exceptions.QueryValidationException;
 import com.datastax.driver.core.schemabuilder.SchemaBuilder;
 import com.scylladb.cdc.cql.MasterCQL;
 import com.scylladb.cdc.cql.CQLConfiguration;
@@ -66,17 +67,25 @@ public class BaseScyllaIntegrationTest {
         driverSessionSrc.execute(SchemaBuilder.dropKeyspace("ks").ifExists());
         driverSessionDst.execute(SchemaBuilder.dropKeyspace("ks").ifExists());
 
-        // Create a test keyspace.
-        driverSessionSrc.execute(SchemaBuilder.createKeyspace("ks").with().replication(
-            new HashMap<String, Object>() {{
-                put("class", "SimpleStrategy");
-                put("replication_factor", "1");
-        }}));
-        driverSessionDst.execute(SchemaBuilder.createKeyspace("ks").with().replication(
-            new HashMap<String, Object>() {{
-                put("class", "SimpleStrategy");
-                put("replication_factor", "1");
-        }}));
+        // Create a test keyspace. Tablets are disabled explicitly: ScyllaDB 6.x enables
+        // them by default for NTS and CDC is incompatible with tablets (issue #16317).
+        // On ScyllaDB < 6.0 the 'tablets' property is unknown; fall back without it.
+        for (Session s : new Session[]{driverSessionSrc, driverSessionDst}) {
+            try {
+                s.execute(
+                    "CREATE KEYSPACE ks WITH replication = " +
+                    "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1} " +
+                    "AND tablets = {'enabled': false}");
+            } catch (QueryValidationException e) {
+                if (e.getMessage() != null && e.getMessage().contains("Unknown property 'tablets'")) {
+                    s.execute(
+                        "CREATE KEYSPACE ks WITH replication = " +
+                        "{'class': 'NetworkTopologyStrategy', 'replication_factor': 1}");
+                } else {
+                    throw e;
+                }
+            }
+        }
 
         maybeWaitForFirstGeneration();
     }


### PR DESCRIPTION
## Summary

Integration tests fail on ScyllaDB 2026.x and 6.x due to two related but distinct issues with keyspace creation.

**ScyllaDB 2026.x** (`latest` in CI):
```
InvalidConfigurationInQueryException: SimpleStrategy doesn't support tablet replication
```
ScyllaDB 2026.x rejects `SimpleStrategy` outright when tablets are enabled.

**ScyllaDB 6.x** (`6.2` in CI):
```
InvalidQueryException: Cannot create CDC log for a table ks.X, because keyspace uses tablets. See issue #16317.
```
ScyllaDB 6.x accepts `NetworkTopologyStrategy` but enables tablet replication by default for NTS keyspaces. CDC is incompatible with tablets (ScyllaDB issue #16317), so CDC table creation fails even after the `SimpleStrategy` fix.

**ScyllaDB 5.x** (`5.2` in CI): no tablets → NTS without any tablet clause works fine.

## Changes

### 1. Replace `SimpleStrategy` with `NetworkTopologyStrategy` (all versions)

Replace `SimpleStrategy` with `NetworkTopologyStrategy` in all keyspace creation statements. The `replication_factor` shorthand key is supported by `NetworkTopologyStrategy` and auto-expands to all data centres; no DC name is required.

### 2. Disable tablets for CDC keyspaces (ScyllaDB 6.x)

Append `AND tablets = {'enabled': false}` to `CREATE KEYSPACE` for all keyspaces that host CDC tables. On ScyllaDB versions that do not recognise the `tablets` property (< 6.0), a catch on `"Unknown property 'tablets'"` retries without the clause — tablets are inactive on those versions anyway.

A new `TestKeyspaceUtils.createWithoutTablets(Session, String)` helper in `scylla-cdc-lib` encapsulates this try/catch pattern for the `lib` integration tests. The `scylla-cdc-driver3` and `scylla-cdc-replicator` base test classes use inline try/catch (one call site each) and also switch from the `SchemaBuilder` API to raw CQL strings — `SchemaBuilder` has no API for ScyllaDB-specific tablet options.

## Affected files (test code only)

| File | Change |
|---|---|
| `scylla-cdc-lib/…/TestKeyspaceUtils.java` | new helper — `createWithoutTablets()` with fallback |
| `scylla-cdc-lib/…/AlterTableBase.java` | NTS + use `TestKeyspaceUtils` |
| `scylla-cdc-lib/…/AlterTableIT.java` | NTS + use `TestKeyspaceUtils` |
| `scylla-cdc-lib/…/AlterUpdateUdtIT.java` | use `TestKeyspaceUtils` |
| `scylla-cdc-lib/…/EmptyGenerationIT.java` | NTS + use `TestKeyspaceUtils` |
| `scylla-cdc-lib/…/FirstStartupLatencyIT.java` | NTS + use `TestKeyspaceUtils` |
| `scylla-cdc-lib/…/PreimagePostimageIT.java` | NTS + use `TestKeyspaceUtils` |
| `scylla-cdc-driver3/…/BaseScyllaIntegrationTest.java` | NTS + inline tablets try/catch; raw CQL replaces `SchemaBuilder` |
| `scylla-cdc-replicator/…/BaseScyllaIntegrationTest.java` | NTS + inline tablets try/catch; raw CQL replaces `SchemaBuilder` |

No production code is affected. The tablets-specific tests (`TabletsIT`, `BaseScyllaTabletsIntegrationTest`) already use `NetworkTopologyStrategy` and are unchanged.

Closes #185