### PR TITLE
fix: bump scylla driver to 3.11.5.17 to remediate netty and jackson CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,8 +19,7 @@
     </modules>
 
     <properties>
-        <scylla.driver.version>3.11.5.13</scylla.driver.version>
-        <netty.version>4.2.15.Final</netty.version>
+        <scylla.driver.version>3.11.5.17</scylla.driver.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>

--- a/scylla-cdc-base/pom.xml
+++ b/scylla-cdc-base/pom.xml
@@ -21,12 +21,6 @@
             <version>${guava.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>${netty.version}</version>
-            <scope>compile</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.flogger</groupId>
             <artifactId>flogger</artifactId>
         </dependency>

--- a/scylla-cdc-driver3/pom.xml
+++ b/scylla-cdc-driver3/pom.xml
@@ -35,30 +35,12 @@
                     <groupId>com.google.guava</groupId>
                     <artifactId>guava</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-common</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>io.netty</groupId>
-                    <artifactId>netty-handler</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>33.5.0-jre</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-common</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>${netty.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.flogger</groupId>


### PR DESCRIPTION
## What

Bumps `scylla.driver.version` from `3.11.5.13` to `3.11.5.17` and removes the Stage 1 netty version overrides.

## Why

Driver `3.11.5.17` ships fixed transitive dependencies that flow into the shaded `scylla-cdc-driver3` jar:

- **netty 4.1.135.Final** — fixes CVE-2026-44249 (CVSS 8.1), CVE-2026-45416 (CVSS 7.5), CVE-2026-50010 (HIGH), via scylladb/java-driver#927
- **jackson 2.18.9** — fixes CVE-2026-54512 through CVE-2026-54518, via scylladb/java-driver#956

## Changes

1. `pom.xml`: bump driver `3.11.5.13` → `3.11.5.17`; remove `netty.version` property.
2. `scylla-cdc-driver3/pom.xml`: remove the `io.netty` exclusions on the driver dependency and the explicit `netty-common` / `netty-handler` re-adds — netty now flows transitively from the driver.
3. `scylla-cdc-base/pom.xml`: remove the `netty-handler` declaration; no base code uses netty.

## Rationale for dropping the 4.2.x override

The previous override pinned netty **4.2.15.Final**, excluding the driver's own netty. Driver 3.x is built and tested against the **4.1.x** line, so aligning to the driver's own **4.1.135.Final** is safer than carrying a cross-minor 4.2.x pin. The only direct netty usage is SSL setup in `Driver3Session` (`SslContext`, `SslContextBuilder`, `SslProvider`) — stable APIs present in both 4.1.x and 4.2.x.

## Verification

`mvn dependency:tree` on `scylla-cdc-driver3` confirms:

```
+- io.netty:netty-handler:jar:4.1.135.Final:compile
|  +- io.netty:netty-common:jar:4.1.135.Final:compile
|  ... (all netty modules 4.1.135.Final)
+- com.fasterxml.jackson.core:jackson-core:jar:2.18.9:compile
\- com.fasterxml.jackson.core:jackson-databind:jar:2.18.9:compile
   \- com.fasterxml.jackson.core:jackson-annotations:jar:2.18.9:compile
```

Compilation of `scylla-cdc-base` and `scylla-cdc-driver3` passes.

## Context

Supersedes #184 (the rejected downstream jackson pin). This implements the "fix it downstream" approach: fix in the driver, release, and consume transitively — the same pattern used for the netty fix.

Tracked in: scylladb/scylla-cdc-source-connector#276