### PR TITLE
fix: bump scylla driver to 3.11.5.18 to remediate netty and lz4 CVEs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     </modules>
 
     <properties>
-        <scylla.driver.version>3.11.5.17</scylla.driver.version>
+        <scylla.driver.version>3.11.5.18</scylla.driver.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>


### PR DESCRIPTION
> [!NOTE]
> **Unblocked — ready for review.** scylladb/java-driver#990 merged into `scylla-3.x` on 2026-08-04 and **3.11.5.18 was published to Maven Central on 2026-08-18** ([tag](https://github.com/scylladb/java-driver/releases/tag/3.11.5.18)). The version this PR pins now resolves, and the Verification section below has been re-run against the real release artifact rather than a local SNAPSHOT.

Bumps `scylla.driver.version` from `3.11.5.17` to `3.11.5.18` to pull in the netty and lz4 CVE fixes transitively.

## What the new driver brings

scylladb/java-driver#990 bumps two properties on `scylla-3.x`, now visible in the published `scylla-driver-parent-3.11.5.18.pom`:

- **netty `4.1.135.Final` → `4.1.136.Final`** — remediates **CVE-2026-59901** (HIGH): `Bzip2Decoder` can be driven into a permanent infinite loop in the RLE state machine of `Bzip2BlockDecompressor.read()`, capturing the event-loop thread.
- **lz4-java `1.10.1` → `1.11.1`** — remediates **CVE-2026-59949** (MEDIUM, CVSS 6.5): JNI-backed XXHash implementations did not validate their byte array arguments, so a null array or an out-of-range `off`/`len` could crash the JVM.

## Why this repo needs the bump

`scylla-cdc-driver3` relocates `io.netty.` → `shaded.com.scylladb.cdc.driver3.` when it shades `scylla-driver-core`, so the netty bytecode is **physically embedded** in the published `scylla-cdc-driver3.jar`. No downstream consumer can override it with `dependencyManagement` — a Confluent Hub scan of `scylla-cdc-source-connector` v2.0.4 flagged exactly this, reporting CVE-2026-59901 against `scylla-cdc-driver3-1.3.12.jar`:

```
$ unzip -p scylla-cdc-driver3-1.3.12.jar META-INF/io.netty.versions.properties
netty-handler.version=4.1.135.Final

$ unzip -l scylla-cdc-driver3-1.3.12.jar | grep Bzip2BlockDecompressor
shaded/com/scylladb/cdc/driver3/handler/codec/compression/Bzip2BlockDecompressor.class
```

Rebuilding against the fixed driver is the only way to clear it.

## Approach

One property, no netty declaration of its own — the same shape as a352c30. The Stage 1 stopgap pattern from 5229bc4 (pinning netty pre-shade, independent of the driver) was deliberately **not** used: it would leave an override to unwind later, and the driver release is needed regardless to fix the *unshaded* netty that downstream consumers resolve directly from `scylla-driver-core`.

## Verification

Re-run against the **released** 3.11.5.18 on Central, with no `-Dscylla.driver.version` override and with any stale `3.11.5.18-SNAPSHOT` purged from `~/.m2` first, so nothing local can mask a resolution problem.

**1. Unit tests — the CI-equivalent command, all 7 modules green:**

```
$ mvn -B -ntp test -DexcludedGroups=integration
[INFO] Java Library for Scylla CDC - base ....... Tests run: 38, Failures: 0, Errors: 0, Skipped: 0
[INFO] Java Library for Scylla CDC - lib ........ Tests run: 50, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

**2. The netty family resolves as a coherent set at 4.1.136.Final:**

```
$ mvn -B -pl scylla-cdc-driver3 dependency:tree
+- com.scylladb:scylla-driver-core:jar:3.11.5.18:compile
|  +- io.netty:netty-handler:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-common:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-resolver:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-buffer:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-transport:jar:4.1.136.Final:compile
|  |  +- io.netty:netty-transport-native-unix-common:jar:4.1.136.Final:compile
|  |  \- io.netty:netty-codec:jar:4.1.136.Final:compile
```

**3. The shaded jar embeds the fixed netty:**

```
$ unzip -p scylla-cdc-driver3/target/scylla-cdc-driver3-1.3.13-SNAPSHOT.jar \
    META-INF/io.netty.versions.properties
netty-handler.version=4.1.136.Final
```

**4. The relocated vulnerable class is genuinely different bytecode** — not just a metadata bump. Comparing the published 1.3.12 jar against this build, same entry path:

```
$ P=shaded/com/scylladb/cdc/driver3/handler/codec/compression/Bzip2BlockDecompressor.class

$ unzip -p ~/.m2/.../scylla-cdc-driver3-1.3.12.jar $P | sha256sum   # netty 4.1.135.Final
8bf9b7531a1c2f153cfe96eeaafe82a031a8b76bf840f72be994418193d7d2b8

$ unzip -p scylla-cdc-driver3-1.3.13-SNAPSHOT.jar $P | sha256sum    # netty 4.1.136.Final
28c564a398e3668ea6b951625f836a29018fd11d244b2e9a2acd59d4c066d5be
```

That is the whole point of the change: the RLE state machine downstream scanners flag is now the patched one.

One caveat worth recording, unrelated to this PR: a full-reactor `mvn install` stops at
`scylla-cdc-replicator`, which fails to compile because it declares no direct `scylla-driver-core`
dependency and instead picks up `com.datastax.driver.core.querybuilder.{Utils, Assignment}` through the
**shaded** `scylla-cdc-driver3` jar, where those classes are relocated. It reproduces identically on
unmodified `master` against the released 3.11.5.17, and it does not affect `mvn test` (which uses the
unshaded `target/classes`), which is why CI is green. Flagging it rather than fixing it here.

## Downstream

Once merged and released as `1.3.13` (master is already at `1.3.13-SNAPSHOT`, so a release from master
cuts tag `scylla-cdc-1.3.13`), this unblocks scylladb/scylla-cdc-source-connector#295, which consumes
`1.3.13` + `3.11.5.18` and deletes the `netty-bom` stopgap it had to pin in the meantime.

Tracked in: scylladb/scylla-cdc-source-connector#293

🤖 Generated with [Claude Code](https://claude.com/claude-code)
