### PR TITLE
feat(cql): make the driver address translator configurable

### DIFF
--- a/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/CQLConfiguration.java
+++ b/scylla-cdc-base/src/main/java/com/scylladb/cdc/cql/CQLConfiguration.java
@@ -9,6 +9,7 @@ import java.util.List;
 
 public class CQLConfiguration {
     private static final ConsistencyLevel DEFAULT_CONSISTENCY_LEVEL = ConsistencyLevel.QUORUM;
+    private static final AddressTranslatorType DEFAULT_ADDRESS_TRANSLATOR = AddressTranslatorType.NONE;
 
     /**
      * The consistency level of read queries to Scylla.
@@ -57,6 +58,12 @@ public class CQLConfiguration {
         ALL
     }
 
+    // Address translator applied to the rpc_address each node advertises.
+    public enum AddressTranslatorType {
+        NONE,
+        EC2_MULTI_REGION
+    }
+
     public final List<InetSocketAddress> contactPoints;
     public final String user;
     public final String password;
@@ -64,6 +71,7 @@ public class CQLConfiguration {
     private final String localDCName;
     private final String localRackName;
     private final ReplicaOrdering replicaOrdering;
+    private final AddressTranslatorType addressTranslator;
     public final SslConfig sslConfig;
     public final int queryOptionsFetchSize;
     // Part of driver's pooling options
@@ -77,6 +85,7 @@ public class CQLConfiguration {
     private CQLConfiguration(List<InetSocketAddress> contactPoints,
                              String user, String password, ConsistencyLevel consistencyLevel,
                              String localDCName, String localRackName, ReplicaOrdering replicaOrdering,
+                             AddressTranslatorType addressTranslator,
                              SslConfig sslConfig, int queryOptionsFetchSize, Integer corePoolLocal,
                              Integer maxPoolLocal, Integer poolingMaxQueueSize,
                              Integer poolingMaxRequestsPerConnectionLocal,
@@ -98,6 +107,7 @@ public class CQLConfiguration {
         this.localDCName = localDCName;
         this.localRackName = localRackName;
         this.replicaOrdering = Preconditions.checkNotNull(replicaOrdering);
+        this.addressTranslator = Preconditions.checkNotNull(addressTranslator);
         this.sslConfig = sslConfig;
         this.queryOptionsFetchSize = queryOptionsFetchSize;
         this.corePoolLocal = corePoolLocal;
@@ -175,6 +185,10 @@ public class CQLConfiguration {
         return replicaOrdering;
     }
 
+    public AddressTranslatorType getAddressTranslator() {
+        return addressTranslator;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -188,6 +202,7 @@ public class CQLConfiguration {
         private String localDCName = null;
         private String localRackName = null;
         private ReplicaOrdering replicaOrdering = ReplicaOrdering.RANDOM;
+        private AddressTranslatorType addressTranslator = DEFAULT_ADDRESS_TRANSLATOR;
         private SslConfig sslConfig = null;
         private int queryOptionsFetchSize = 0;
         private Integer corePoolLocal = null;
@@ -297,6 +312,11 @@ public class CQLConfiguration {
             return this;
         }
 
+        public Builder withAddressTranslator(AddressTranslatorType addressTranslator) {
+            this.addressTranslator = Preconditions.checkNotNull(addressTranslator);
+            return this;
+        }
+
         public Builder withSslConfig(SslConfig sslConfig) {
             this.sslConfig = sslConfig;
             return this;
@@ -371,7 +391,7 @@ public class CQLConfiguration {
         }
 
         public CQLConfiguration build() {
-            return new CQLConfiguration(contactPoints, user, password, consistencyLevel, localDCName, localRackName, replicaOrdering, sslConfig, queryOptionsFetchSize, corePoolLocal, maxPoolLocal, poolingMaxQueueSize, poolingMaxRequestsPerConnectionLocal, poolTimeoutMillis, defaultPort);
+            return new CQLConfiguration(contactPoints, user, password, consistencyLevel, localDCName, localRackName, replicaOrdering, addressTranslator, sslConfig, queryOptionsFetchSize, corePoolLocal, maxPoolLocal, poolingMaxQueueSize, poolingMaxRequestsPerConnectionLocal, poolTimeoutMillis, defaultPort);
         }
     }
 }

--- a/scylla-cdc-base/src/test/java/com/scylladb/cdc/cql/CQLConfigurationTest.java
+++ b/scylla-cdc-base/src/test/java/com/scylladb/cdc/cql/CQLConfigurationTest.java
@@ -1,0 +1,42 @@
+package com.scylladb.cdc.cql;
+
+import com.scylladb.cdc.cql.CQLConfiguration.AddressTranslatorType;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class CQLConfigurationTest {
+    private static CQLConfiguration.Builder builderWithContactPoint() {
+        return CQLConfiguration.builder().addContactPoint("127.0.0.1");
+    }
+
+    @Test
+    public void testAddressTranslatorDefaultsToNone() {
+        CQLConfiguration configuration = builderWithContactPoint().build();
+        assertEquals(AddressTranslatorType.NONE, configuration.getAddressTranslator());
+    }
+
+    @Test
+    public void testAddressTranslatorEc2MultiRegion() {
+        CQLConfiguration configuration = builderWithContactPoint()
+                .withAddressTranslator(AddressTranslatorType.EC2_MULTI_REGION)
+                .build();
+        assertEquals(AddressTranslatorType.EC2_MULTI_REGION, configuration.getAddressTranslator());
+    }
+
+    @Test
+    public void testAddressTranslatorExplicitNone() {
+        CQLConfiguration configuration = builderWithContactPoint()
+                .withAddressTranslator(AddressTranslatorType.EC2_MULTI_REGION)
+                .withAddressTranslator(AddressTranslatorType.NONE)
+                .build();
+        assertEquals(AddressTranslatorType.NONE, configuration.getAddressTranslator());
+    }
+
+    @Test
+    public void testAddressTranslatorRejectsNull() {
+        assertThrows(NullPointerException.class,
+                () -> builderWithContactPoint().withAddressTranslator(null));
+    }
+}

--- a/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Session.java
+++ b/scylla-cdc-driver3/src/main/java/com/scylladb/cdc/cql/driver3/Driver3Session.java
@@ -2,6 +2,7 @@ package com.scylladb.cdc.cql.driver3;
 
 import com.datastax.driver.core.*;
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy;
+import com.datastax.driver.core.policies.EC2MultiRegionAddressTranslator;
 import com.datastax.driver.core.policies.RackAwareRoundRobinPolicy;
 import com.datastax.driver.core.policies.RoundRobinPolicy;
 import com.datastax.driver.core.policies.TokenAwarePolicy;
@@ -34,6 +35,10 @@ public class Driver3Session implements AutoCloseable {
         clusterBuilder = clusterBuilder
             .withPort(cqlConfiguration.defaultPort)
             .addContactPointsWithPorts(cqlConfiguration.contactPoints);
+
+        if (cqlConfiguration.getAddressTranslator() == CQLConfiguration.AddressTranslatorType.EC2_MULTI_REGION) {
+            clusterBuilder = clusterBuilder.withAddressTranslator(new EC2MultiRegionAddressTranslator());
+        }
 
         PoolingOptions poolingOptions = new PoolingOptions();
         if (cqlConfiguration.poolingMaxQueueSize != null) {


### PR DESCRIPTION
## What

Make the driver's address translator configurable in `CQLConfiguration`, and apply it when building the Driver3 `Cluster`.

- New `CQLConfiguration.AddressTranslatorType { NONE, EC2_MULTI_REGION }` + `CQLConfiguration.Builder.withAddressTranslator(...)`, default `NONE`.
- `Driver3Session` installs the driver's `EC2MultiRegionAddressTranslator` only when `EC2_MULTI_REGION` is selected; `NONE` keeps the current behaviour byte-for-byte.

## Why

A Scylla cluster that advertises **public** `rpc_address`es (e.g. Scylla Cloud) is unreachable over VPC peering: the driver connects to the contact point, then discovers peers at their public addresses, which are not routable from inside the peered VPC. `EC2_MULTI_REGION` installs `EC2MultiRegionAddressTranslator`, which reverse-DNS resolves each address to its `ec2-<ip>.compute-1.amazonaws.com` hostname; AWS split-horizon DNS then resolves that to the **private** IP inside the VPC and the public IP from outside — with no cluster-side change.

This is the library half of the fix for the connector issue scylladb/scylla-cdc-source-connector#73; the connector-side config key is a companion PR (linked below).

## Tests

- **Unit** — new `CQLConfigurationTest`: default is `NONE`, `withAddressTranslator` round-trips `EC2_MULTI_REGION`, explicit `NONE`, and `null` → NPE. Passes on **JDK 11 and JDK 17**; output stays Java-11 bytecode (`maven.compiler.target=11`).
- **End-to-end (via the companion connector built on this branch, dep `1.3.14`):**
  - *Local* — Kafka Connect (`cp-kafka-connect`) + the Scylla CDC connector against a public Scylla Cloud cluster: with `EC2_MULTI_REGION` the task reached `RUNNING` and streamed CDC records; default `NONE` unchanged.
  - *In a peered VPC (Kubernetes / EKS pod, private Route53 contact point)* — a clean A/B on the same jar, cluster and VPC, flipping only this option:
    - `EC2_MULTI_REGION` → the CDC driver added all nodes via their **private** IPs (`ec2-<ip>.compute-1.amazonaws.com/10.x.x.x`), shard-aware pools established, CDC records streamed.
    - `NONE` → peers added at their raw **public** IPs (untranslated), dozens of connection failures to those unreachable addresses, zero records.

## Note

The connector's `ScyllaVersionChecker` builds a separate, unshaded driver `Cluster` that does not receive this translator; in the peered-VPC run it added public host objects but still succeeded (version detected from a reachable private host). Worth covering separately; not addressed here.
